### PR TITLE
Migración a MVVM: ViewModels, repositorios, DI manual y ViewBinding

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,6 +33,9 @@ android {
     kotlinOptions {
         jvmTarget = "11"
     }
+    buildFeatures {
+        viewBinding = true
+    }
 }
 
 dependencies {
@@ -43,6 +46,8 @@ dependencies {
     implementation(libs.androidx.constraintlayout)
     implementation("com.google.code.gson:gson:2.10.1")
     implementation(libs.androidx.recyclerview)
+    implementation(libs.androidx.lifecycle.viewmodel.ktx)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".PalletCocinasApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/escorial/pallet_cocinas/AsociarProductoActivity.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/AsociarProductoActivity.kt
@@ -2,69 +2,47 @@ package com.escorial.pallet_cocinas
 
 import android.app.AlertDialog
 import android.content.Intent
-import android.content.SharedPreferences
 import android.os.Bundle
-import android.util.Log
 import android.view.KeyEvent
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.AdapterView
-import android.widget.EditText
-import android.widget.TextView
-import androidx.appcompat.app.AppCompatActivity
 import android.widget.ArrayAdapter
-import android.widget.Button
-import android.widget.ProgressBar
-import android.widget.Spinner
+import android.widget.TextView
 import android.widget.Toast
-import androidx.appcompat.widget.AppCompatImageButton
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.coroutines.launch
-import retrofit2.HttpException
-import java.io.IOException
-import androidx.core.content.edit
-import androidx.recyclerview.widget.ItemTouchHelper
-import com.escorial.pallet_cocinas.utils.apiMessage
+import com.escorial.pallet_cocinas.data.model.Product
+import com.escorial.pallet_cocinas.databinding.ActivityAsociarProductoBinding
+import com.escorial.pallet_cocinas.di.ViewModelFactory
+import com.escorial.pallet_cocinas.di.appContainer
+import com.escorial.pallet_cocinas.viewmodel.AsociarProductoEvent
+import com.escorial.pallet_cocinas.viewmodel.AsociarProductoUiState
+import com.escorial.pallet_cocinas.viewmodel.AsociarProductoViewModel
 import com.google.android.material.snackbar.Snackbar
-import com.google.gson.Gson
+import kotlinx.coroutines.launch
 
 class AsociarProductoActivity : AppCompatActivity() {
 
-    lateinit var prefs: SharedPreferences
+    private lateinit var binding: ActivityAsociarProductoBinding
+    private lateinit var viewModel: AsociarProductoViewModel
+    private lateinit var productAdapter: ProductAdapter
 
-    private var isProductRequestInProgress = false
-    private var isPalletRequestInProgress = false
-    private var isSubmitRequestInProgress = false
-
-    lateinit var selectedProductType: String
-
-    lateinit var productsRecyclerView: RecyclerView
-    lateinit var productAdapter: ProductAdapter
-    lateinit var productEditText: EditText
-    lateinit var palletEditText: EditText
-    lateinit var productSpinner: Spinner
-    lateinit var submitButton: Button
-    lateinit var progressBar: ProgressBar
-    lateinit var changePalletButton: AppCompatImageButton
-
-    lateinit var api: ApiService
-
-    lateinit var palletRepository: PalletRepository
-
-    var productsList: ArrayList<Product> = ArrayList()
-    lateinit var pickeadosTextView: TextView
-
-    val itemTouchHelperCallback = object : ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT) {
+    private val itemTouchHelperCallback = object : ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT) {
         override fun onMove(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder, target: RecyclerView.ViewHolder): Boolean {
             return false
         }
 
         override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
             val position = viewHolder.adapterPosition
-            val item = productsList[position]
+            val item = viewModel.productsList[position]
 
             if (direction == ItemTouchHelper.LEFT || direction == ItemTouchHelper.RIGHT) {
                 if (!item.deleted)
@@ -80,18 +58,20 @@ class AsociarProductoActivity : AppCompatActivity() {
             .setTitle("Confirmar restauración")
             .setMessage("Seguro que quieres volver a asociar este elemento?")
             .setPositiveButton("Sí") { _, _ ->
-                val res = restoreItem(item)
-                if (res) {
-                    Snackbar.make(productsRecyclerView, "Ítem restaurado", Snackbar.LENGTH_LONG)
+                val restored = viewModel.restoreProduct(item)
+                val position = viewModel.productsList.indexOf(item)
+                productAdapter.notifyItemChanged(position)
+                if (restored) {
+                    Snackbar.make(binding.productsRecyclerView, "Ítem restaurado", Snackbar.LENGTH_LONG)
                         .setAction("Deshacer") {
-                            deleteItem(item)
+                            viewModel.deleteProduct(item)
+                            productAdapter.notifyItemChanged(position)
                         }
                         .show()
                 }
             }
             .setNegativeButton("Cancelar") { _, _ ->
-                val position = productsList.indexOf(item)
-                productAdapter.notifyItemChanged(position)
+                productAdapter.notifyItemChanged(viewModel.productsList.indexOf(item))
             }
             .setCancelable(false)
             .show()
@@ -102,282 +82,78 @@ class AsociarProductoActivity : AppCompatActivity() {
             .setTitle("Confirmar eliminación")
             .setMessage("Seguro que quieres desasociar este elemento?")
             .setPositiveButton("Sí") { _, _ ->
-                deleteItem(item)
-                Snackbar.make(productsRecyclerView, "Ítem eliminado", Snackbar.LENGTH_LONG)
+                viewModel.deleteProduct(item)
+                val position = viewModel.productsList.indexOf(item)
+                productAdapter.notifyItemChanged(position)
+                Snackbar.make(binding.productsRecyclerView, "Ítem eliminado", Snackbar.LENGTH_LONG)
                     .setAction("Deshacer") {
-                        restoreItem(item)
+                        viewModel.restoreProduct(item)
+                        productAdapter.notifyItemChanged(position)
                     }
                     .show()
             }
             .setNegativeButton("Cancelar") { _, _ ->
-                val position = productsList.indexOf(item)
-                productAdapter.notifyItemChanged(position)
+                productAdapter.notifyItemChanged(viewModel.productsList.indexOf(item))
             }
             .setCancelable(false)
             .show()
     }
 
-    private fun deleteItem(item: Product) {
-        val position = productsList.indexOf(item)
-        productsList[position].deleted = true
-        productAdapter.notifyItemChanged(position)
-    }
-    private fun restoreItem(item: Product): Boolean {
-        val position = productsList.indexOf(item)
-        if (getNotDeletedProducts().count() >= item.maxCantByPallet) {
-            Toast.makeText(this@AsociarProductoActivity, "Cantidad máxima de productos por pallet alcanzada", Toast.LENGTH_LONG).show()
-            productAdapter.notifyItemChanged(position)
-            return false
-        }
-        productsList[position].deleted = false
-        productAdapter.notifyItemChanged(position)
-        return true
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_asociar_producto)
+        binding = ActivityAsociarProductoBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        viewModel = ViewModelProvider(
+            this,
+            ViewModelFactory {
+                AsociarProductoViewModel(
+                    appContainer.palletRepository,
+                    appContainer.productRepository,
+                    appContainer.sessionRepository
+                )
+            }
+        )[AsociarProductoViewModel::class.java]
 
         loadControls()
 
-        restoreUIState()
-
-        val topBar = findViewById<TopBar>(R.id.topBar)
-
-        val username = prefs.getString("username", "null")
-        val fullName = prefs.getString("fullName", "null")
-
-        topBar.setUserInfo(username, fullName)
-        topBar.setLogoutButtonVisibility(true)
-        topBar.setOnLogoutClickListener  {
+        val state = viewModel.uiState.value
+        binding.topBar.setUserInfo(state.username, state.fullName)
+        binding.topBar.setLogoutButtonVisibility(true)
+        binding.topBar.setOnLogoutClickListener {
             logout()
             Toast.makeText(this@AsociarProductoActivity, "Logout", Toast.LENGTH_SHORT).show()
         }
 
-        productEditText.setOnEditorActionListener(createEnterListener("product"))
-        palletEditText.setOnEditorActionListener(createEnterListener("pallet"))
+        binding.productEditText.setOnEditorActionListener(createEnterListener("product"))
+        binding.palletEditText.setOnEditorActionListener(createEnterListener("pallet"))
 
-        submitButton.setOnClickListener { submit() }
-
-        changePalletButton.setOnClickListener { resetUIState() }
-
-        palletEditText.requestFocus()
-    }
-
-    private fun createEnterListener(type: String): TextView.OnEditorActionListener {
-        return TextView.OnEditorActionListener { v, actionId, event ->
-            if (actionId == EditorInfo.IME_ACTION_DONE || actionId == 5 ||
-                (event?.keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_DOWN)
-            ) {
-                when (type) {
-                    "product" -> coroutineProduct()
-                    "pallet" -> coroutinePallet()
-                }
-                v.clearFocus()
-                val imm = getSystemService(InputMethodManager::class.java)
-                imm.hideSoftInputFromWindow(v.windowToken, 0)
-                return@OnEditorActionListener true
-            }
-            false
-        }
-    }
-
-    private fun coroutineProduct() {
-        if (isProductRequestInProgress)
-            return
-        progressBar.visibility = View.VISIBLE
-        lifecycleScope.launch {
-            try {
-                val productSerial = productEditText.text.toString()
-                if (productSerial.isEmpty()) {
-                    productEditText.text.clear()
-                    productEditText.requestFocus()
-                    throw Exception("Campo de producto vacío")
-                }
-                var product = if (selectedProductType == "COCINA") {
-                    api.getProduct(productSerial, "COCINA")
-                } else if (selectedProductType == "TERMO/CALEFON") {
-                    api.getProduct(productSerial, "TERMOTANQUE")
-                } else if (selectedProductType == "IMPORTADO") {
-                    api.getProduct(productSerial, "IMPORTADO")
-                }
-                else {
-                    throw Exception("Debe seleccionar un tipo de producto para continuar")
-                }
-                handleProduct(product)
-            } catch (h: HttpException) {
-                Toast.makeText(this@AsociarProductoActivity, "Error HTTP\n${h.apiMessage()}", Toast.LENGTH_LONG).show()
-                Log.d("API_ERROR", "Error HTTP. ${h.message}")
-            } catch (i: IOException) {
-                Toast.makeText(this@AsociarProductoActivity, "Error de conexion.", Toast.LENGTH_LONG).show()
-                Log.d("API_ERROR", "Error de conexion. ${i.message}")
-            } catch (e: Exception) {
-                Toast.makeText(this@AsociarProductoActivity, "Error al obtener datos.", Toast.LENGTH_LONG).show()
-                Log.d("API_ERROR", "Error al obtener datos. ${e.message}")
-            }
-            finally {
-                progressBar.visibility = View.GONE
-                isProductRequestInProgress = false
-            }
-        }
-    }
-
-    private fun handleProduct(product: Product) {
-        if (!product.isAvailable) {
-            Log.d("Product", "Producto ya palletizado")
-            Toast.makeText(this@AsociarProductoActivity, "Producto ya palletizado", Toast.LENGTH_LONG).show()
-            productEditText.text.clear()
-            productEditText.requestFocus()
-            return
-        }
-        if (getNotDeletedProducts().count() == product.maxCantByPallet) {
-            Log.d("Product", "Cantidad máxima de productos por pallet alcanzada")
-            Toast.makeText(this@AsociarProductoActivity, "Cantidad máxima de productos por pallet alcanzada", Toast.LENGTH_LONG).show()
-            productEditText.text.clear()
-            productEditText.requestFocus()
-            return
-        }
-        if (productsList.contains(product)){
-            Log.d("Product", "El producto ya fue pickeado")
-            Toast.makeText(this@AsociarProductoActivity, "El producto ya fue pickeado", Toast.LENGTH_LONG).show()
-            productEditText.text.clear()
-            productEditText.requestFocus()
-            return
-        }
-        if (!productsList.isEmpty() && productsList.last().productId != product.productId) {
-            Log.d("Product", "Tipo de producto incorrecto")
-            Toast.makeText(this@AsociarProductoActivity, "Tipo de producto incorrecto", Toast.LENGTH_LONG).show()
-            productEditText.text.clear()
-            productEditText.requestFocus()
-            return
+        binding.submitButton.setOnClickListener {
+            viewModel.onSubmit(binding.palletEditText.text.toString())
         }
 
-        productsList.add(product)
-        productEditText.text.clear()
-        productAdapter.notifyDataSetChanged()
-        productEditText.requestFocus()
-    }
+        binding.changePalletButton.setOnClickListener { viewModel.onChangePalletClicked() }
 
-    private fun coroutinePallet() {
-        if (isPalletRequestInProgress) return
-
-        progressBar.visibility = View.VISIBLE
-        isPalletRequestInProgress = true
+        binding.palletEditText.requestFocus()
 
         lifecycleScope.launch {
-            try {
-                val palletCode = palletEditText.text.toString()
-                val pallet = palletRepository.getPalletWithProducts(palletCode)
-                handlePallet(pallet)
-            } catch (h: HttpException) {
-                Toast.makeText(this@AsociarProductoActivity, "Error HTTP.\n${h.apiMessage()}", Toast.LENGTH_LONG).show()
-            } catch (i: IOException) {
-                Toast.makeText(this@AsociarProductoActivity, "Error de conexion.\n${i.message}", Toast.LENGTH_LONG).show()
-            } catch (e: Exception) {
-                Toast.makeText(this@AsociarProductoActivity, "Error al obtener datos.\n${e.message}", Toast.LENGTH_LONG).show()
-            } finally {
-                progressBar.visibility = View.GONE
-                isPalletRequestInProgress = false
-            }
-        }
-    }
-
-    private fun handlePallet(pallet: Pallet) {
-        if (pallet.Products != null && pallet.Products!!.isNotEmpty()) {
-            for (product in pallet.Products)
-                productsList.add(product)
-            productAdapter.notifyDataSetChanged()
-            if (pallet.Products?.firstOrNull()?.type == "COCINA") {
-                productSpinner.setSelection(0)
-                productSpinner.isEnabled = false
-            }
-            else if (pallet.Products?.firstOrNull()?.type == "TERMOTANQUE") {
-                productSpinner.setSelection(1)
-                productSpinner.isEnabled = false
-            }
-            var product = pallet.Products?.firstOrNull()
-        }
-
-        palletEditText.isEnabled = false
-        productEditText.isEnabled = true
-        productEditText.requestFocus()
-    }
-
-    private fun submit() {
-        if (isSubmitRequestInProgress)
-            return
-        if (productsList.isEmpty())
-            return
-        if (getNotDeletedProducts().count() != productsList.first().maxCantByPallet) {
-            Toast.makeText(this@AsociarProductoActivity, "Debe asociar todos los productos", Toast.LENGTH_LONG).show()
-            return
-        }
-        isSubmitRequestInProgress = true
-        progressBar.visibility = View.VISIBLE
-        var palletPost = Pallet(
-            id = java.util.UUID.randomUUID(),
-            descripcion = "",
-            fecha_alta = "",
-            codigo = palletEditText.text.toString(),
-            transferir = false,
-            Products = productsList,
-            Usuario = prefs.getString("username", "")!!
-        )
-        lifecycleScope.launch {
-            try {
-                var response = api.postPalletProducts(palletPost)
-                if (response.isSuccessful) {
-                    Toast.makeText(this@AsociarProductoActivity, "Productos asociados al pallet", Toast.LENGTH_LONG).show()
-                    Log.d("Product", "Productos asociados al pallet. $response")
-                    resetUIState()
-                }
-                else {
-                    var error = response.errorBody()?.string()
-                    Toast.makeText(this@AsociarProductoActivity, "Error al asociar productos al pallet. ${error}", Toast.LENGTH_LONG).show()
-                    Log.d("Product", "Error al asociar productos al pallet. $response")
-                }
-            } catch (h: HttpException) {
-                Toast.makeText(this@AsociarProductoActivity, "Error HTTP\n${h.apiMessage()}", Toast.LENGTH_LONG).show()
-                Log.d("API_ERROR", "Error HTTP. ${h.message}")
-            } catch (i: IOException) {
-                Toast.makeText(this@AsociarProductoActivity, "Error de conexion.", Toast.LENGTH_LONG).show()
-                Log.d("API_ERROR", "Error de conexion. ${i.message}")
-            } catch (e: Exception) {
-                Toast.makeText(this@AsociarProductoActivity, "Error al obtener datos.", Toast.LENGTH_LONG).show()
-                Log.d("API_ERROR", "Error al obtener datos. ${e.message}")
-            }
-            finally {
-                progressBar.visibility = View.GONE
-                isSubmitRequestInProgress = false
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch { viewModel.uiState.collect { render(it) } }
+                launch { viewModel.events.collect { handleEvent(it) } }
+                launch { viewModel.errorEvents.collect { Toast.makeText(this@AsociarProductoActivity, it, Toast.LENGTH_LONG).show() } }
             }
         }
     }
 
     private fun loadControls() {
-        Log.d("LoadControls", "Loading controls")
-        prefs = getSharedPreferences("user_prefs", MODE_PRIVATE)
+        binding.palletEditText.setText(viewModel.initialPalletText)
+        binding.productEditText.setText(viewModel.initialProductText)
 
-        api = ApiClient.getApiService(this)
-        palletRepository = PalletRepository(api)
+        binding.productsRecyclerView.layoutManager = LinearLayoutManager(this)
 
-        progressBar = findViewById(R.id.progressBar)
-        palletEditText = findViewById(R.id.palletEditText)
-        productEditText = findViewById(R.id.productEditText)
-        productEditText.isEnabled = false
-        submitButton = findViewById(R.id.submitButton)
-
-        productSpinner = findViewById(R.id.productSpinner)
-        configProductSpinner()
-
-        productsRecyclerView = findViewById(R.id.productsRecyclerView)
-        productsRecyclerView.layoutManager = LinearLayoutManager(this)
-
-        //COMENTE ESTO PORQUE LAS LINEAS DIVISORAS SON FEAS :d
-        //var divider = DividerItemDecoration(this, DividerItemDecoration.VERTICAL)
-        //productsRecyclerView.addItemDecoration(divider)
-
-        productAdapter = ProductAdapter(productsList)
-        productsRecyclerView.adapter = productAdapter
+        productAdapter = ProductAdapter(viewModel.productsList)
+        binding.productsRecyclerView.adapter = productAdapter
+        productAdapter.notifyDataSetChanged()
 
         productAdapter.registerAdapterDataObserver(object : RecyclerView.AdapterDataObserver() {
             override fun onChanged() {
@@ -401,121 +177,107 @@ class AsociarProductoActivity : AppCompatActivity() {
             }
         })
 
-
         val itemTouchHelper = ItemTouchHelper(itemTouchHelperCallback)
-        itemTouchHelper.attachToRecyclerView(productsRecyclerView)
+        itemTouchHelper.attachToRecyclerView(binding.productsRecyclerView)
 
-        changePalletButton = findViewById(R.id.changePalletButton)
-
-        pickeadosTextView = findViewById(R.id.pickeadosTextView)
-
+        configProductSpinner()
     }
-
-    private fun actualizarContadorPickeados() {
-        val count = getNotDeletedProducts().size
-        val pickeadosTextView = findViewById<TextView>(R.id.pickeadosTextView)
-
-        if (productsList.isNotEmpty()) {
-            val max = productsList.first().maxCantByPallet
-            pickeadosTextView.text = "Pickeados: $count/$max"
-
-            if (count == max) {
-                pickeadosTextView.setTextColor(getColor(android.R.color.holo_green_dark))
-            } else {
-                pickeadosTextView.setTextColor(getColor(android.R.color.black))
-            }
-        } else {
-            pickeadosTextView.text = "Pickeados: $count"
-            pickeadosTextView.setTextColor(getColor(android.R.color.black))
-        }
-    }
-
-
-
 
     private fun configProductSpinner() {
-        val options2 = resources.getStringArray(R.array.tipo_producto)
-        val adapter = ArrayAdapter(this, android.R.layout.simple_spinner_item, options2)
-        val position = prefs.getString("selectedProductIndex", 0.toString())!!.toInt()
-        productSpinner.setSelection(position)
+        val options = resources.getStringArray(R.array.tipo_producto)
+        val adapter = ArrayAdapter(this, android.R.layout.simple_spinner_item, options)
         adapter.setDropDownViewResource(R.layout.product_dropdown_item)
+        binding.productSpinner.adapter = adapter
+        binding.productSpinner.setSelection(viewModel.uiState.value.spinnerSelection)
 
-        productSpinner.adapter = adapter
-        productSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+        binding.productSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
                 val selectedOption = parent.getItemAtPosition(position).toString()
-                Toast.makeText(this@AsociarProductoActivity, "Seleccionaste: $selectedOption", Toast.LENGTH_SHORT).show()
-                selectedProductType = selectedOption
-                prefs.edit { putString("selectedProductIndex", position.toString()) }
-                productSpinner.setSelection(prefs.getString("selectedProductIndex", 0.toString())!!.toInt())
+                viewModel.onProductTypeSelected(position, selectedOption)
             }
 
             override fun onNothingSelected(parent: AdapterView<*>) {
-                Toast.makeText(this@AsociarProductoActivity, "No seleccionaste nada", Toast.LENGTH_SHORT).show()
+                viewModel.onProductTypeNothingSelected()
             }
         }
     }
 
-    private fun resetUIState() {
-        productsList.clear()
-        productAdapter.notifyDataSetChanged()
-
-        palletEditText.text.clear()
-        palletEditText.isEnabled = true
-        productEditText.text.clear()
-        productEditText.isEnabled = false
-
-        productSpinner.isEnabled = true
-        productSpinner.setSelection(prefs.getString("selectedProductIndex", 0.toString())!!.toInt())
-
-        prefs.edit {
-            remove("palletText")
-            remove("productText")
-            remove("productsList")
+    private fun render(state: AsociarProductoUiState) {
+        binding.palletEditText.isEnabled = state.palletFieldEnabled
+        binding.productEditText.isEnabled = state.productFieldEnabled
+        binding.productSpinner.isEnabled = state.productSpinnerEnabled
+        if (binding.productSpinner.selectedItemPosition != state.spinnerSelection) {
+            binding.productSpinner.setSelection(state.spinnerSelection)
         }
-        palletEditText.requestFocus()
+        binding.progressBar.visibility =
+            if (state.isLoadingProduct || state.isLoadingPallet || state.isSubmitting) View.VISIBLE else View.GONE
     }
+
+    private fun handleEvent(event: AsociarProductoEvent) {
+        when (event) {
+            is AsociarProductoEvent.ShowToast ->
+                Toast.makeText(this, event.message, Toast.LENGTH_LONG).show()
+            is AsociarProductoEvent.FocusProductField -> {
+                if (event.clearFirst) binding.productEditText.text.clear()
+                binding.productEditText.requestFocus()
+            }
+            is AsociarProductoEvent.ProductsListChanged ->
+                productAdapter.notifyDataSetChanged()
+            is AsociarProductoEvent.ResetFields -> {
+                productAdapter.notifyDataSetChanged()
+                binding.palletEditText.text.clear()
+                binding.productEditText.text.clear()
+                binding.palletEditText.requestFocus()
+            }
+        }
+    }
+
+    private fun actualizarContadorPickeados() {
+        val notDeleted = viewModel.productsList.filter { !it.deleted }
+        val count = notDeleted.size
+
+        if (viewModel.productsList.isNotEmpty()) {
+            val max = viewModel.productsList.first().maxCantByPallet
+            binding.pickeadosTextView.text = "Pickeados: $count/$max"
+
+            if (count == max) {
+                binding.pickeadosTextView.setTextColor(getColor(android.R.color.holo_green_dark))
+            } else {
+                binding.pickeadosTextView.setTextColor(getColor(android.R.color.black))
+            }
+        } else {
+            binding.pickeadosTextView.text = "Pickeados: $count"
+            binding.pickeadosTextView.setTextColor(getColor(android.R.color.black))
+        }
+    }
+
     override fun onPause() {
         super.onPause()
-        prefs.edit {
-            putString("palletText", palletEditText.text.toString())
-            putString("productText", productEditText.text.toString())
-            putBoolean("palletEditTextEnabled", palletEditText.isEnabled)
-            putBoolean("productEditTextEnabled", productEditText.isEnabled)
-            putBoolean("productSpinnerEnabled", productSpinner.isEnabled)
-            putString("productsList", Gson().toJson(productsList))
-        }
-    }
-    fun restoreUIState() {
-        palletEditText.setText(prefs.getString("palletText", ""))
-        productEditText.setText(prefs.getString("productText", ""))
-
-        palletEditText.isEnabled = prefs.getBoolean("palletEditTextEnabled", true)
-        productEditText.isEnabled = prefs.getBoolean("productEditTextEnabled", false)
-        productSpinner.isEnabled = prefs.getBoolean("productSpinnerEnabled", true)
-
-        actualizarContadorPickeados()
-
-        val jsonList = prefs.getString("productsList", null)
-        if (!jsonList.isNullOrEmpty()) {
-            val type = object : com.google.gson.reflect.TypeToken<ArrayList<Product>>() {}.type
-            val restoredList: ArrayList<Product> = Gson().fromJson(jsonList, type)
-            productsList.clear()
-            productsList.addAll(restoredList)
-            productAdapter.notifyDataSetChanged()
-        }
+        viewModel.onPause(binding.palletEditText.text.toString(), binding.productEditText.text.toString())
     }
 
     private fun logout() {
-        val sharedPreferences: SharedPreferences = getSharedPreferences("user_prefs", MODE_PRIVATE)
-        sharedPreferences.edit() { remove("isLoggedIn") }
-
+        viewModel.logout()
         val intent = Intent(this, LoginActivity::class.java)
         startActivity(intent)
         finish()
     }
 
-    private fun getNotDeletedProducts(): ArrayList<Product> {
-        return ArrayList(productsList.filter { !it.deleted })
+    private fun createEnterListener(type: String): TextView.OnEditorActionListener {
+        return TextView.OnEditorActionListener { v, actionId, event ->
+            if (actionId == EditorInfo.IME_ACTION_DONE || actionId == 5 ||
+                (event?.keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_DOWN)
+            ) {
+                when (type) {
+                    "product" -> viewModel.onProductSerialSubmitted(binding.productEditText.text.toString())
+                    "pallet" -> viewModel.onPalletCodeSubmitted(binding.palletEditText.text.toString())
+                }
+                v.clearFocus()
+                val imm = getSystemService(InputMethodManager::class.java)
+                imm.hideSoftInputFromWindow(v.windowToken, 0)
+                return@OnEditorActionListener true
+            }
+            false
+        }
     }
 }

--- a/app/src/main/java/com/escorial/pallet_cocinas/ConfigActivity.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/ConfigActivity.kt
@@ -1,55 +1,49 @@
 package com.escorial.pallet_cocinas
 
-import android.content.Context
 import android.os.Bundle
 import android.view.View
-import android.widget.Button
-import android.widget.EditText
-import android.widget.LinearLayout
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.widget.AppCompatImageButton
+import androidx.lifecycle.ViewModelProvider
+import com.escorial.pallet_cocinas.databinding.ActivityConfigBinding
+import com.escorial.pallet_cocinas.di.ViewModelFactory
+import com.escorial.pallet_cocinas.di.appContainer
+import com.escorial.pallet_cocinas.viewmodel.ConfigViewModel
 
 class ConfigActivity : AppCompatActivity() {
 
-    private val contraseñaCorrecta = "Aria9278"
+    private lateinit var binding: ActivityConfigBinding
+    private lateinit var viewModel: ConfigViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_config)
+        binding = ActivityConfigBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        val layoutConfig = findViewById<LinearLayout>(R.id.layoutConfig)
-        val layoutPassword = findViewById<LinearLayout>(R.id.layoutPassword)
-        val etPassword = findViewById<EditText>(R.id.etPassword)
-        val btnValidar = findViewById<Button>(R.id.btnValidar)
+        viewModel = ViewModelProvider(
+            this,
+            ViewModelFactory { ConfigViewModel(appContainer.configRepository) }
+        )[ConfigViewModel::class.java]
 
-        val etApiUrl = findViewById<EditText>(R.id.etApiUrl)
-        val btnGuardar = findViewById<Button>(R.id.btnGuardar)
-        val btnCancelar = findViewById<AppCompatImageButton>(R.id.btnCancelar)
+        binding.layoutConfig.visibility = View.GONE
 
-        val prefs = getSharedPreferences("configuracion", Context.MODE_PRIVATE)
-
-        // Ocultar el layout de configuración hasta validar
-        layoutConfig.visibility = View.GONE
-
-        btnValidar.setOnClickListener {
-            if (etPassword.text.toString() == contraseñaCorrecta) {
-                layoutPassword.visibility = View.GONE
-                layoutConfig.visibility = View.VISIBLE
-                etApiUrl.setText(prefs.getString("api_url", ""))
+        binding.btnValidar.setOnClickListener {
+            if (viewModel.validatePassword(binding.etPassword.text.toString())) {
+                binding.layoutPassword.visibility = View.GONE
+                binding.layoutConfig.visibility = View.VISIBLE
+                binding.etApiUrl.setText(viewModel.uiState.value.apiUrl)
             } else {
                 Toast.makeText(this, "Contraseña incorrecta", Toast.LENGTH_SHORT).show()
             }
         }
 
-        btnGuardar.setOnClickListener {
-            val nuevaUrl = etApiUrl.text.toString()
-            prefs.edit().putString("api_url", nuevaUrl).apply()
+        binding.btnGuardar.setOnClickListener {
+            viewModel.saveApiUrl(binding.etApiUrl.text.toString())
             Toast.makeText(this, "Configuración guardada", Toast.LENGTH_SHORT).show()
             finish()
         }
 
-        btnCancelar.setOnClickListener {
+        binding.btnCancelar.setOnClickListener {
             finish()
         }
     }

--- a/app/src/main/java/com/escorial/pallet_cocinas/ExpedicionActivity.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/ExpedicionActivity.kt
@@ -1,58 +1,57 @@
 package com.escorial.pallet_cocinas
 
 import android.content.Intent
-import android.content.SharedPreferences
 import android.os.Bundle
-import android.widget.Button
 import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.edit
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.lifecycle.ViewModelProvider
+import com.escorial.pallet_cocinas.databinding.ActivityExpedicionBinding
+import com.escorial.pallet_cocinas.di.ViewModelFactory
+import com.escorial.pallet_cocinas.di.appContainer
+import com.escorial.pallet_cocinas.viewmodel.ExpedicionViewModel
 
 class ExpedicionActivity : AppCompatActivity() {
 
-    lateinit var btnTransferir: Button
-    lateinit var btnDesasociar: Button
-    lateinit var prefs: SharedPreferences
+    private lateinit var binding: ActivityExpedicionBinding
+    private lateinit var viewModel: ExpedicionViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        setContentView(R.layout.activity_expedicion)
-        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
+        binding = ActivityExpedicionBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        ViewCompat.setOnApplyWindowInsetsListener(binding.main) { v, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
         }
 
+        viewModel = ViewModelProvider(
+            this,
+            ViewModelFactory { ExpedicionViewModel(appContainer.sessionRepository) }
+        )[ExpedicionViewModel::class.java]
+
         loadControls()
     }
 
     private fun loadControls() {
-        prefs = getSharedPreferences("user_prefs", MODE_PRIVATE)
+        val state = viewModel.uiState.value
 
-        val username = prefs.getString("username", "null")
-        val fullName = prefs.getString("fullName", "null")
-        val topBar = findViewById<TopBar>(R.id.topBar)
-
-        topBar.setUserInfo(username, fullName)
-        topBar.setLogoutButtonVisibility(true)
-        topBar.setOnLogoutClickListener  {
+        binding.topBar.setUserInfo(state.username, state.fullName)
+        binding.topBar.setLogoutButtonVisibility(true)
+        binding.topBar.setOnLogoutClickListener {
             logout()
             Toast.makeText(this@ExpedicionActivity, "Logout", Toast.LENGTH_SHORT).show()
         }
-        btnTransferir = findViewById(R.id.btnTransferir)
-        btnDesasociar = findViewById(R.id.btnDesasociar)
-        btnDesasociar.setOnClickListener { startPickeoPalletActivity("desasociar") }
-        btnTransferir.setOnClickListener { startPickeoPalletActivity("transferir") }
+        binding.btnDesasociar.setOnClickListener { startPickeoPalletActivity("desasociar") }
+        binding.btnTransferir.setOnClickListener { startPickeoPalletActivity("transferir") }
     }
 
     private fun logout() {
-        val sharedPreferences: SharedPreferences = getSharedPreferences("user_prefs", MODE_PRIVATE)
-        sharedPreferences.edit() { remove("isLoggedIn") }
-
+        viewModel.logout()
         val intent = Intent(this, LoginActivity::class.java)
         startActivity(intent)
         finish()

--- a/app/src/main/java/com/escorial/pallet_cocinas/LoginActivity.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/LoginActivity.kt
@@ -1,117 +1,73 @@
 package com.escorial.pallet_cocinas
 
 import android.content.Intent
-import android.content.SharedPreferences
-import retrofit2.HttpException
 import android.os.Bundle
-import android.util.Log
-import androidx.appcompat.app.AppCompatActivity
-import android.widget.Button
-import android.widget.EditText
-import android.widget.Toast
-import androidx.core.content.edit
-import androidx.lifecycle.lifecycleScope
-import kotlinx.coroutines.launch
-import android.widget.ProgressBar
 import android.view.View
-import androidx.appcompat.widget.AppCompatImageButton
-import com.escorial.pallet_cocinas.utils.apiMessage
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import android.widget.Toast
+import com.escorial.pallet_cocinas.databinding.ActivityLoginBinding
+import com.escorial.pallet_cocinas.di.ViewModelFactory
+import com.escorial.pallet_cocinas.di.appContainer
+import com.escorial.pallet_cocinas.viewmodel.LoginNavEvent
+import com.escorial.pallet_cocinas.viewmodel.LoginUiState
+import com.escorial.pallet_cocinas.viewmodel.LoginViewModel
+import kotlinx.coroutines.launch
 
 class LoginActivity : AppCompatActivity() {
 
-    lateinit var sharedPreferences: SharedPreferences
-
-    lateinit var btnLogin: Button
-    lateinit var etUsername: EditText
-    lateinit var etPassword: EditText
-    lateinit var progressBar: ProgressBar
-
-    val api get() = ApiClient.getApiService(this)
+    private lateinit var binding: ActivityLoginBinding
+    private lateinit var viewModel: LoginViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        binding = ActivityLoginBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        setContentView(R.layout.activity_login)
+        viewModel = ViewModelProvider(
+            this,
+            ViewModelFactory { LoginViewModel(appContainer.loginRepository, appContainer.sessionRepository) }
+        )[LoginViewModel::class.java]
 
-        loadControls()
-
-        val isLoggedIn = sharedPreferences.getBoolean("isLoggedIn", false)
-
-        if (isLoggedIn) {
-            val loggedUser = sharedPreferences.getString("username", "")
-            if (loggedUser == "expedicion")
-                startMainActivity(true)
-            else
-                startMainActivity(false)
+        val initialNavEvent = viewModel.initialNavEvent
+        if (initialNavEvent != null) {
+            navigate(initialNavEvent)
             return
         }
 
-    }
-
-    private fun login(username: String, password: String) {
-        progressBar.visibility = View.VISIBLE
-        if (username == "expedicion" && password == "expedicion") {
-            saveLoggedUserData("expedicion", "Expedicion")
-            startMainActivity(true)
-            return
+        binding.btnLogin.setOnClickListener {
+            viewModel.login(binding.etUsername.text.toString(), binding.etPassword.text.toString())
         }
+
+        binding.btnConfiguracion.setOnClickListener {
+            startActivity(Intent(this, ConfigActivity::class.java))
+        }
+
         lifecycleScope.launch {
-            try {
-                var login = Login(username, password)
-                var response = api.postLogin(login)
-                if (response.isSuccessful) {
-                    var login = response.body()
-                    saveLoggedUserData(login!!.usuario_sistema, login.nombre)
-                    startMainActivity(false)
-                }
-            }
-            catch (h: HttpException) {
-                Toast.makeText(this@LoginActivity, "Error HTTP\n${h.apiMessage()}", Toast.LENGTH_LONG).show()
-                Log.d("API_ERROR", "Error HTTP. ${h.message}")
-            }
-            catch (e: Exception) {
-                Log.d("API_ERROR", "Excepcion no controlada.\n${e.message}")
-                Toast.makeText(this@LoginActivity, "Error al obtener datos.", Toast.LENGTH_LONG).show()
-            }
-            finally {
-                progressBar.visibility = View.GONE
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch { viewModel.uiState.collect { render(it) } }
+                launch { viewModel.navEvents.collect { navigate(it) } }
+                launch { viewModel.errorEvents.collect { Toast.makeText(this@LoginActivity, it, Toast.LENGTH_LONG).show() } }
             }
         }
     }
 
-    private fun startMainActivity(bypass: Boolean) {
-        val intent: Intent = if (bypass)
+    private fun render(state: LoginUiState) {
+        binding.progressBar.visibility = if (state.isLoading) View.VISIBLE else View.GONE
+    }
+
+    private fun navigate(event: LoginNavEvent) {
+        val bypass = when (event) {
+            is LoginNavEvent.ToMain -> event.bypass
+        }
+        val intent = if (bypass)
             Intent(this, ExpedicionActivity::class.java)
         else
             Intent(this, AsociarProductoActivity::class.java)
         startActivity(intent)
         finish()
-    }
-
-    private fun loadControls() {
-        sharedPreferences = getSharedPreferences("user_prefs", MODE_PRIVATE)
-        //val topBar = findViewById<TopBar>(R.id.topBar)
-        //topBar.setUserInfo("", "")
-        //topBar.setLogoutButtonVisibility(false)
-        btnLogin = findViewById<Button>(R.id.btnLogin)
-        etUsername = findViewById<EditText>(R.id.etUsername)
-        etPassword = findViewById<EditText>(R.id.etPassword)
-        btnLogin.setOnClickListener {
-            login(etUsername.text.toString(), etPassword.text.toString())
-        }
-        progressBar = findViewById<ProgressBar>(R.id.progressBar)
-
-        //config button
-        val configButton = findViewById<AppCompatImageButton>(R.id.btnConfiguracion)
-        configButton.setOnClickListener {
-            val intent = Intent(this, ConfigActivity::class.java)
-            startActivity(intent)
-        }
-    }
-
-    private fun saveLoggedUserData(username: String, fullName: String) {
-        sharedPreferences.edit { putString("username", username) }
-        sharedPreferences.edit { putString("fullName", fullName) }
-        sharedPreferences.edit { putBoolean("isLoggedIn", true) }
     }
 }

--- a/app/src/main/java/com/escorial/pallet_cocinas/PalletAdapter.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/PalletAdapter.kt
@@ -1,35 +1,27 @@
 package com.escorial.pallet_cocinas
 
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
+import com.escorial.pallet_cocinas.data.model.Pallet
+import com.escorial.pallet_cocinas.databinding.PalletItemBinding
 
 class PalletAdapter(private val pallets: List<Pallet>) :
     RecyclerView.Adapter<PalletAdapter.PalletViewHolder>() {
 
-    class PalletViewHolder(view: View) : RecyclerView.ViewHolder(view) {
-        val tvPalletCode = view.findViewById<TextView>(R.id.tvPalletCode)
-        val tvProductCode = view.findViewById<TextView>(R.id.tvProductCode)
-        val tvProductCant = view.findViewById<TextView>(R.id.tvProductCant)
-        val itemLayout: View = view
-    }
+    class PalletViewHolder(val binding: PalletItemBinding) : RecyclerView.ViewHolder(binding.root)
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PalletViewHolder {
-        val view = LayoutInflater.from(parent.context)
-            .inflate(R.layout.pallet_item, parent, false)
-        return PalletViewHolder(view)
+        val binding = PalletItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return PalletViewHolder(binding)
     }
 
     override fun onBindViewHolder(holder: PalletViewHolder, position: Int) {
         val pallet = pallets[position]
-        holder.tvPalletCode.text = pallet.codigo
-        holder.tvProductCode.text = "${pallet.Products?.get(0)?.productCode}"
-        holder.tvProductCant.text = "${pallet.Products?.get(0)?.maxCantByPallet}"
+        holder.binding.tvPalletCode.text = pallet.codigo
+        holder.binding.tvProductCode.text = "${pallet.Products?.get(0)?.productCode}"
+        holder.binding.tvProductCant.text = "${pallet.Products?.get(0)?.maxCantByPallet}"
     }
 
     override fun getItemCount() = pallets.size
-
-
 }

--- a/app/src/main/java/com/escorial/pallet_cocinas/PalletCocinasApp.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/PalletCocinasApp.kt
@@ -1,0 +1,14 @@
+package com.escorial.pallet_cocinas
+
+import android.app.Application
+import com.escorial.pallet_cocinas.di.AppContainer
+
+class PalletCocinasApp : Application() {
+
+    lateinit var container: AppContainer
+
+    override fun onCreate() {
+        super.onCreate()
+        container = AppContainer(this)
+    }
+}

--- a/app/src/main/java/com/escorial/pallet_cocinas/PickeoPalletActivity.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/PickeoPalletActivity.kt
@@ -2,75 +2,63 @@ package com.escorial.pallet_cocinas
 
 import android.app.AlertDialog
 import android.content.Intent
-import android.content.SharedPreferences
 import android.os.Bundle
 import android.view.KeyEvent
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
-import android.widget.Button
-import android.widget.EditText
-import android.widget.ProgressBar
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.edit
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.escorial.pallet_cocinas.utils.apiMessage
+import com.escorial.pallet_cocinas.databinding.ActivityPickeoPalletBinding
+import com.escorial.pallet_cocinas.di.ViewModelFactory
+import com.escorial.pallet_cocinas.di.appContainer
+import com.escorial.pallet_cocinas.viewmodel.PickeoPalletEvent
+import com.escorial.pallet_cocinas.viewmodel.PickeoPalletUiState
+import com.escorial.pallet_cocinas.viewmodel.PickeoPalletViewModel
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
-import retrofit2.HttpException
-import retrofit2.Response
-import java.io.IOException
 
 class PickeoPalletActivity : AppCompatActivity() {
-    lateinit var prefs: SharedPreferences
 
-    var isPalletRequestInProgress = false
-    lateinit var transferirButton: Button
-    lateinit var lblTitle: TextView
-    lateinit var palletEditText: EditText
-    lateinit var palletsRecyclerView: RecyclerView
-    lateinit var progressBar: ProgressBar
-    lateinit var api: ApiService
-    var palletsList: ArrayList<Pallet> = ArrayList()
-    lateinit var palletRepository: PalletRepository
-    lateinit var palletAdapter: PalletAdapter
-    lateinit var tipo: String
+    private lateinit var binding: ActivityPickeoPalletBinding
+    private lateinit var viewModel: PickeoPalletViewModel
+    private lateinit var palletAdapter: PalletAdapter
 
-    private var lastDeletedItem: Pallet? = null
-    private var lastDeletedItemPosition: Int = -1
-
-    val itemTouchHelperCallback = object : ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT) {
+    private val itemTouchHelperCallback = object : ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT) {
         override fun onMove(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder, target: RecyclerView.ViewHolder): Boolean {
             return false
         }
 
         override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
             val position = viewHolder.adapterPosition
-            val item = palletsList[position]
-
             if (direction == ItemTouchHelper.LEFT || direction == ItemTouchHelper.RIGHT) {
-                swipeActionDelete(item, position)
+                swipeActionDelete(position)
             }
         }
     }
 
-    private fun swipeActionDelete(item: Pallet, position: Int) {
+    private fun swipeActionDelete(position: Int) {
         AlertDialog.Builder(this)
             .setTitle("Confirmar eliminación")
             .setMessage("¿Seguro que quieres desasociar este elemento?")
             .setPositiveButton("Sí") { _, _ ->
-                deleteItem(item, position)
-                Snackbar.make(palletsRecyclerView, "Ítem eliminado", Snackbar.LENGTH_LONG)
+                viewModel.eliminarPallet(position)
+                palletAdapter.notifyItemRemoved(position)
+                Snackbar.make(binding.rvPallets, "Ítem eliminado", Snackbar.LENGTH_LONG)
                     .setAction("Deshacer") {
-                        restoreItem()
+                        val restoredPosition = viewModel.restaurarUltimoEliminado()
+                        if (restoredPosition != null) palletAdapter.notifyItemInserted(restoredPosition)
                     }
                     .show()
             }
@@ -81,219 +69,101 @@ class PickeoPalletActivity : AppCompatActivity() {
             .show()
     }
 
-    private fun deleteItem(item: Pallet, position: Int) {
-        lastDeletedItem = item
-        lastDeletedItemPosition = position
-
-        palletsList.removeAt(position)
-        palletAdapter.notifyItemRemoved(position)
-    }
-
-    private fun restoreItem() {
-        if (lastDeletedItem != null && lastDeletedItemPosition != -1) {
-            palletsList.add(lastDeletedItemPosition, lastDeletedItem!!)
-            palletAdapter.notifyItemInserted(lastDeletedItemPosition)
-
-            lastDeletedItem = null
-            lastDeletedItemPosition = -1
-        }
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        setContentView(R.layout.activity_pickeo_pallet)
-        loadControls()
-        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
+        binding = ActivityPickeoPalletBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        ViewCompat.setOnApplyWindowInsetsListener(binding.main) { v, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
         }
+
+        val tipo = intent.getStringExtra("tipo") ?: ""
+        viewModel = ViewModelProvider(
+            this,
+            ViewModelFactory { PickeoPalletViewModel(appContainer.expedicionRepository, appContainer.sessionRepository, tipo) }
+        )[PickeoPalletViewModel::class.java]
+
+        loadControls(tipo)
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch { viewModel.uiState.collect { render(it) } }
+                launch { viewModel.events.collect { handleEvent(it) } }
+                launch { viewModel.errorEvents.collect { Toast.makeText(this@PickeoPalletActivity, it, Toast.LENGTH_LONG).show() } }
+            }
+        }
     }
 
-    private fun loadControls() {
-        tipo = intent.getStringExtra("tipo") ?: ""
+    private fun loadControls(tipo: String) {
+        val state = viewModel.uiState.value
 
-        prefs = getSharedPreferences("user_prefs", MODE_PRIVATE)
-
-        val topBar = findViewById<TopBar>(R.id.topBar)
-
-        val username = prefs.getString("username", "null")
-        val fullName = prefs.getString("fullName", "null")
-
-        topBar.setUserInfo(username, fullName)
-        topBar.setLogoutButtonVisibility(true)
-        topBar.setOnLogoutClickListener  {
+        binding.topBar.setUserInfo(state.username, state.fullName)
+        binding.topBar.setLogoutButtonVisibility(true)
+        binding.topBar.setOnLogoutClickListener {
             logout()
             Toast.makeText(this@PickeoPalletActivity, "Logout", Toast.LENGTH_SHORT).show()
         }
-        api = ApiClient.getApiService(this)
-        lblTitle = findViewById(R.id.lblTitle)
-        lblTitle.text = lblTitle.text.toString().replace("{type}", if(tipo == "transferir") "Transferencia" else "Desasociación")
-        palletRepository = PalletRepository(api)
-        progressBar = findViewById(R.id.progressBar)
-        transferirButton = findViewById(R.id.btnTransferir)
-        transferirButton.setOnClickListener {
+
+        binding.lblTitle.text = binding.lblTitle.text.toString()
+            .replace("{type}", if (tipo == "transferir") "Transferencia" else "Desasociación")
+
+        binding.btnTransferir.setOnClickListener {
             AlertDialog.Builder(this)
                 .setTitle("Confirmar ${if (tipo == "transferir") "transferencia" else "desasociación"}?")
                 .setMessage("¿Seguro que quieres ${if (tipo == "transferir") "transferir" else "desasociar"} este elemento?")
-                .setPositiveButton("Sí") { _, _ ->
-                    transferir()
-                }
+                .setPositiveButton("Sí") { _, _ -> viewModel.confirmarAccion() }
                 .setNegativeButton("Cancelar", null)
                 .show()
         }
         if (tipo == "desasociar") {
-            transferirButton.text = "Desasociar"
+            binding.btnTransferir.text = "Desasociar"
         }
-        palletsRecyclerView = findViewById(R.id.rvPallets)
-        palletEditText = findViewById(R.id.etPallet)
-        palletEditText.setOnEditorActionListener(createEnterListener("pallet"))
-        palletsRecyclerView.layoutManager = LinearLayoutManager(this)
-        palletAdapter = PalletAdapter(palletsList)
-        palletsRecyclerView.adapter = palletAdapter
+
+        binding.etPallet.setOnEditorActionListener(createEnterListener())
+        binding.rvPallets.layoutManager = LinearLayoutManager(this)
+        palletAdapter = PalletAdapter(viewModel.palletsList)
+        binding.rvPallets.adapter = palletAdapter
         val itemTouchHelper = ItemTouchHelper(itemTouchHelperCallback)
-        itemTouchHelper.attachToRecyclerView(palletsRecyclerView)
+        itemTouchHelper.attachToRecyclerView(binding.rvPallets)
+    }
+
+    private fun render(state: PickeoPalletUiState) {
+        binding.progressBar.visibility = if (state.isLoading) View.VISIBLE else View.GONE
+    }
+
+    private fun handleEvent(event: PickeoPalletEvent) {
+        when (event) {
+            is PickeoPalletEvent.ShowToast -> Toast.makeText(this, event.message, Toast.LENGTH_LONG).show()
+            is PickeoPalletEvent.ListChanged -> {
+                palletAdapter.notifyDataSetChanged()
+                binding.etPallet.text.clear()
+                binding.etPallet.requestFocus()
+            }
+        }
     }
 
     private fun logout() {
-        val sharedPreferences: SharedPreferences = getSharedPreferences("user_prefs", MODE_PRIVATE)
-        sharedPreferences.edit() { remove("isLoggedIn") }
-
+        viewModel.logout()
         val intent = Intent(this, LoginActivity::class.java)
         startActivity(intent)
         finish()
     }
 
-    private fun createEnterListener(type: String): TextView.OnEditorActionListener {
+    private fun createEnterListener(): TextView.OnEditorActionListener {
         return TextView.OnEditorActionListener { v, actionId, event ->
             if (actionId == EditorInfo.IME_ACTION_DONE || actionId == 5 ||
                 (event?.keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_DOWN)
             ) {
-                when (type) {
-                    "pallet" -> coroutinePallet()
-                }
+                viewModel.buscarPallet(binding.etPallet.text.toString())
                 v.clearFocus()
                 val imm = getSystemService(InputMethodManager::class.java)
                 imm.hideSoftInputFromWindow(v.windowToken, 0)
                 return@OnEditorActionListener true
             }
             false
-        }
-    }
-
-    private fun coroutinePallet() {
-        if (isPalletRequestInProgress) return
-
-        progressBar.visibility = View.VISIBLE
-        isPalletRequestInProgress = true
-
-        lifecycleScope.launch {
-            try {
-                val palletCode = palletEditText.text.toString()
-                val pallet = palletRepository.getPalletWithProducts(palletCode)
-                handlePallet(pallet)
-            } catch (h: HttpException) {
-                Toast.makeText(this@PickeoPalletActivity, "Error HTTP.\n${h.apiMessage()}", Toast.LENGTH_LONG).show()
-            } catch (i: IOException) {
-                Toast.makeText(this@PickeoPalletActivity, "Error de conexion.\n${i.message}", Toast.LENGTH_LONG).show()
-            } catch (e: Exception) {
-                Toast.makeText(this@PickeoPalletActivity, "Error al obtener datos.\n${e.message}", Toast.LENGTH_LONG).show()
-            } finally {
-                progressBar.visibility = View.GONE
-                isPalletRequestInProgress = false
-            }
-        }
-    }
-
-    private fun handlePallet(pallet: Pallet) {
-        try {
-            val products = pallet.Products ?: return
-            if (products.isEmpty()) {
-                Toast.makeText(this@PickeoPalletActivity, "El pallet no tiene productos asociados.", Toast.LENGTH_LONG).show()
-                return
-            }
-            if (palletsList.contains(pallet)) {
-                Toast.makeText(this@PickeoPalletActivity, "Pallet ya pickeado.", Toast.LENGTH_LONG).show()
-                return
-            }
-
-            if (tipo == "transferir") {
-                if (pallet.transferir) {
-                    Toast.makeText(
-                        this@PickeoPalletActivity,
-                        "Pallet ya transferido.",
-                        Toast.LENGTH_LONG
-                    ).show()
-                    return
-                }
-            }
-
-            palletsList.add(pallet)
-        }
-        catch (e: Exception) {
-            Toast.makeText(this@PickeoPalletActivity, "Error al obtener datos.\n${e.message}", Toast.LENGTH_LONG).show()
-        }
-        finally {
-            palletAdapter.notifyDataSetChanged()
-            palletEditText.text.clear()
-            palletEditText.requestFocus()
-        }
-    }
-
-
-    private fun transferir() {
-        if (isPalletRequestInProgress) {
-            Toast.makeText(this@PickeoPalletActivity, "Ya hay una transferencia en curso.", Toast.LENGTH_LONG).show()
-            return
-        }
-
-        if (palletsList.isEmpty()) {
-            Toast.makeText(this@PickeoPalletActivity, "No hay pallets seleccionados.", Toast.LENGTH_LONG).show()
-            return
-        }
-
-        isPalletRequestInProgress = true
-        progressBar.visibility = View.VISIBLE
-
-        lifecycleScope.launch {
-            try {
-                var response: Response<Unit> = Response.success(Unit)
-
-                if (tipo == "transferir") {
-                    response = api.postPalletTransfer(palletsList)
-                } else if (tipo == "desasociar") {
-                    palletsList.forEach { pallet ->
-                        pallet.Products?.forEach { product ->
-                            product.deleted = true
-                        }
-                        response = api.postPalletProducts(pallet)
-                    }
-                } else {
-                    return@launch
-                }
-
-                if (response.isSuccessful) {
-                    var message = ""
-                    if (tipo == "transferir") {
-                        message = "Transferencia"
-                    } else if (tipo == "desasociar") {
-                        message = "Desasociación"
-                    }
-                    Toast.makeText(this@PickeoPalletActivity, "${message} exitosa.", Toast.LENGTH_LONG).show()
-                    palletsList.clear()
-                    palletAdapter.notifyDataSetChanged()
-                    palletEditText.text.clear()
-                    palletEditText.requestFocus()
-                }
-            }
-            catch (e: Exception) {
-                Toast.makeText(this@PickeoPalletActivity, "Error.\n${e.message}", Toast.LENGTH_LONG).show()
-            }
-            finally {
-                isPalletRequestInProgress = false
-                progressBar.visibility = View.GONE
-            }
         }
     }
 }

--- a/app/src/main/java/com/escorial/pallet_cocinas/ProductAdapter.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/ProductAdapter.kt
@@ -1,40 +1,31 @@
 package com.escorial.pallet_cocinas
 
-import android.graphics.Color
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
-import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
+import com.escorial.pallet_cocinas.data.model.Product
+import com.escorial.pallet_cocinas.databinding.ProductItemBinding
 
 class ProductAdapter(private val products: List<Product>) :
     RecyclerView.Adapter<ProductAdapter.ProductViewHolder>() {
 
-    class ProductViewHolder(view: View) : RecyclerView.ViewHolder(view) {
-        val tvProductCode: TextView = view.findViewById(R.id.tvProductCode)
-        val tvProductSerial: TextView = view.findViewById(R.id.tvProductSerial)
-        val tvProductType: TextView = view.findViewById(R.id.productTypeTextView)
-        val itemLayout: View = view
-    }
+    class ProductViewHolder(val binding: ProductItemBinding) : RecyclerView.ViewHolder(binding.root)
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProductViewHolder {
-        val view = LayoutInflater.from(parent.context)
-            .inflate(R.layout.product_item, parent, false)
-        return ProductViewHolder(view)
+        val binding = ProductItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ProductViewHolder(binding)
     }
 
     override fun onBindViewHolder(holder: ProductViewHolder, position: Int) {
         val product = products[position]
-        holder.tvProductCode.text = "${product.productCode}"
-        holder.tvProductSerial.text = "${product.serial}"
-        holder.tvProductType.text = "${product.type}"
+        holder.binding.tvProductCode.text = "${product.productCode}"
+        holder.binding.tvProductSerial.text = "${product.serial}"
+        holder.binding.productTypeTextView.text = "${product.type}"
 
         if (product.deleted) {
-            holder.itemLayout.setBackgroundResource(R.drawable.item_deleted_background)
+            holder.binding.root.setBackgroundResource(R.drawable.item_deleted_background)
         } else {
-            //holder.itemLayout.setBackgroundColor(Color.WHITE)
-            holder.itemLayout.setBackgroundResource(R.drawable.rounded_input_text)
+            holder.binding.root.setBackgroundResource(R.drawable.rounded_input_text)
         }
     }
 

--- a/app/src/main/java/com/escorial/pallet_cocinas/TopBar.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/TopBar.kt
@@ -3,39 +3,27 @@ package com.escorial.pallet_cocinas
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
-import android.view.View
 import android.widget.LinearLayout
-import android.widget.TextView
-import android.widget.Button
 import androidx.core.view.isVisible
+import com.escorial.pallet_cocinas.databinding.TopBarBinding
 
 class TopBar(context: Context, attrs: AttributeSet) : LinearLayout(context, attrs) {
 
-    private val usernameLabel: TextView
-    private val completeNameLabel: TextView
-    private val logoutButton: View
-
-    init {
-        LayoutInflater.from(context).inflate(R.layout.top_bar, this, true)
-
-        usernameLabel = findViewById(R.id.usernameLabel)
-        completeNameLabel = findViewById(R.id.completeNameLabel)
-        logoutButton = findViewById(R.id.logoutButton)
-    }
+    private val binding = TopBarBinding.inflate(LayoutInflater.from(context), this, true)
 
     fun setUserInfo(username: String?, completeName: String?) {
-        usernameLabel.text = username ?: ""
-        completeNameLabel.text = completeName ?: ""
+        binding.usernameLabel.text = username ?: ""
+        binding.completeNameLabel.text = completeName ?: ""
 
-        usernameLabel.isVisible = username != null
-        completeNameLabel.isVisible = completeName != null
+        binding.usernameLabel.isVisible = username != null
+        binding.completeNameLabel.isVisible = completeName != null
     }
 
     fun setLogoutButtonVisibility(isVisible: Boolean) {
-        logoutButton.isVisible = isVisible
+        binding.logoutButton.isVisible = isVisible
     }
 
     fun setOnLogoutClickListener(listener: OnClickListener) {
-        logoutButton.setOnClickListener(listener)
+        binding.logoutButton.setOnClickListener(listener)
     }
 }

--- a/app/src/main/java/com/escorial/pallet_cocinas/data/model/Login.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/data/model/Login.kt
@@ -1,4 +1,4 @@
-package com.escorial.pallet_cocinas
+package com.escorial.pallet_cocinas.data.model
 
 import java.util.UUID
 

--- a/app/src/main/java/com/escorial/pallet_cocinas/data/model/Pallet.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/data/model/Pallet.kt
@@ -1,4 +1,4 @@
-package com.escorial.pallet_cocinas
+package com.escorial.pallet_cocinas.data.model
 
 import java.util.UUID
 

--- a/app/src/main/java/com/escorial/pallet_cocinas/data/model/Product.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/data/model/Product.kt
@@ -1,4 +1,4 @@
-package com.escorial.pallet_cocinas
+package com.escorial.pallet_cocinas.data.model
 
 import java.util.UUID
 

--- a/app/src/main/java/com/escorial/pallet_cocinas/data/remote/ApiClient.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/data/remote/ApiClient.kt
@@ -1,4 +1,4 @@
-package com.escorial.pallet_cocinas
+package com.escorial.pallet_cocinas.data.remote
 
 import android.content.Context
 import retrofit2.Retrofit

--- a/app/src/main/java/com/escorial/pallet_cocinas/data/remote/ApiService.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/data/remote/ApiService.kt
@@ -1,5 +1,9 @@
-package com.escorial.pallet_cocinas
+package com.escorial.pallet_cocinas.data.remote
 
+import com.escorial.pallet_cocinas.data.model.Login
+import com.escorial.pallet_cocinas.data.model.Pallet
+import com.escorial.pallet_cocinas.data.model.Product
+import com.escorial.pallet_cocinas.data.model.loginResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST

--- a/app/src/main/java/com/escorial/pallet_cocinas/data/repository/ConfigRepository.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/data/repository/ConfigRepository.kt
@@ -1,0 +1,15 @@
+package com.escorial.pallet_cocinas.data.repository
+
+import android.content.Context
+import androidx.core.content.edit
+
+class ConfigRepository(context: Context) {
+
+    private val prefs = context.getSharedPreferences("configuracion", Context.MODE_PRIVATE)
+
+    fun getApiUrl(): String = prefs.getString("api_url", "") ?: ""
+
+    fun setApiUrl(url: String) {
+        prefs.edit { putString("api_url", url) }
+    }
+}

--- a/app/src/main/java/com/escorial/pallet_cocinas/data/repository/ExpedicionRepository.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/data/repository/ExpedicionRepository.kt
@@ -1,0 +1,25 @@
+package com.escorial.pallet_cocinas.data.repository
+
+import com.escorial.pallet_cocinas.data.model.Pallet
+import com.escorial.pallet_cocinas.data.remote.ApiService
+import retrofit2.Response
+
+class ExpedicionRepository(
+    private val api: ApiService,
+    private val palletRepository: PalletRepository
+) {
+
+    suspend fun buscarPallet(codigo: String): Pallet = palletRepository.getPalletWithProducts(codigo)
+
+    suspend fun transferirPallets(pallets: List<Pallet>): Response<Unit> =
+        api.postPalletTransfer(ArrayList(pallets))
+
+    suspend fun desasociarPallets(pallets: List<Pallet>): Response<Unit> {
+        var response: Response<Unit> = Response.success(Unit)
+        pallets.forEach { pallet ->
+            pallet.Products?.forEach { product -> product.deleted = true }
+            response = api.postPalletProducts(pallet)
+        }
+        return response
+    }
+}

--- a/app/src/main/java/com/escorial/pallet_cocinas/data/repository/LoginRepository.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/data/repository/LoginRepository.kt
@@ -1,0 +1,13 @@
+package com.escorial.pallet_cocinas.data.repository
+
+import com.escorial.pallet_cocinas.data.model.Login
+import com.escorial.pallet_cocinas.data.model.loginResponse
+import com.escorial.pallet_cocinas.data.remote.ApiService
+
+class LoginRepository(private val api: ApiService) {
+
+    suspend fun login(username: String, password: String): loginResponse? {
+        val response = api.postLogin(Login(username, password))
+        return if (response.isSuccessful) response.body() else null
+    }
+}

--- a/app/src/main/java/com/escorial/pallet_cocinas/data/repository/PalletRepository.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/data/repository/PalletRepository.kt
@@ -1,4 +1,7 @@
-package com.escorial.pallet_cocinas
+package com.escorial.pallet_cocinas.data.repository
+
+import com.escorial.pallet_cocinas.data.model.Pallet
+import com.escorial.pallet_cocinas.data.remote.ApiService
 
 class PalletRepository(private val api: ApiService) {
 

--- a/app/src/main/java/com/escorial/pallet_cocinas/data/repository/ProductRepository.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/data/repository/ProductRepository.kt
@@ -1,0 +1,13 @@
+package com.escorial.pallet_cocinas.data.repository
+
+import com.escorial.pallet_cocinas.data.model.Pallet
+import com.escorial.pallet_cocinas.data.model.Product
+import com.escorial.pallet_cocinas.data.remote.ApiService
+import retrofit2.Response
+
+class ProductRepository(private val api: ApiService) {
+
+    suspend fun getProduct(serial: String, tipo: String): Product = api.getProduct(serial, tipo)
+
+    suspend fun asociarProductos(pallet: Pallet): Response<Unit> = api.postPalletProducts(pallet)
+}

--- a/app/src/main/java/com/escorial/pallet_cocinas/data/repository/SessionRepository.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/data/repository/SessionRepository.kt
@@ -1,0 +1,29 @@
+package com.escorial.pallet_cocinas.data.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+
+class SessionRepository(context: Context) {
+
+    val preferences: SharedPreferences =
+        context.getSharedPreferences("user_prefs", Context.MODE_PRIVATE)
+
+    fun isLoggedIn(): Boolean = preferences.getBoolean("isLoggedIn", false)
+
+    fun getUsername(default: String = "null"): String? = preferences.getString("username", default)
+
+    fun getFullName(default: String = "null"): String? = preferences.getString("fullName", default)
+
+    fun saveSession(username: String, fullName: String) {
+        preferences.edit {
+            putString("username", username)
+            putString("fullName", fullName)
+            putBoolean("isLoggedIn", true)
+        }
+    }
+
+    fun logout() {
+        preferences.edit { remove("isLoggedIn") }
+    }
+}

--- a/app/src/main/java/com/escorial/pallet_cocinas/di/AppContainer.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/di/AppContainer.kt
@@ -1,0 +1,31 @@
+package com.escorial.pallet_cocinas.di
+
+import android.content.Context
+import com.escorial.pallet_cocinas.data.remote.ApiClient
+import com.escorial.pallet_cocinas.data.remote.ApiService
+import com.escorial.pallet_cocinas.data.repository.ConfigRepository
+import com.escorial.pallet_cocinas.data.repository.ExpedicionRepository
+import com.escorial.pallet_cocinas.data.repository.LoginRepository
+import com.escorial.pallet_cocinas.data.repository.PalletRepository
+import com.escorial.pallet_cocinas.data.repository.ProductRepository
+import com.escorial.pallet_cocinas.data.repository.SessionRepository
+
+class AppContainer(private val context: Context) {
+
+    // No se cachea: preserva el comportamiento de ApiClient.getApiService(),
+    // que reconstruye el Retrofit si "api_url" cambió desde ConfigActivity.
+    private val apiService: ApiService
+        get() = ApiClient.getApiService(context)
+
+    val sessionRepository: SessionRepository by lazy { SessionRepository(context) }
+    val configRepository: ConfigRepository by lazy { ConfigRepository(context) }
+
+    val palletRepository: PalletRepository
+        get() = PalletRepository(apiService)
+    val loginRepository: LoginRepository
+        get() = LoginRepository(apiService)
+    val productRepository: ProductRepository
+        get() = ProductRepository(apiService)
+    val expedicionRepository: ExpedicionRepository
+        get() = ExpedicionRepository(apiService, palletRepository)
+}

--- a/app/src/main/java/com/escorial/pallet_cocinas/di/ViewModelFactory.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/di/ViewModelFactory.kt
@@ -1,0 +1,14 @@
+package com.escorial.pallet_cocinas.di
+
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.escorial.pallet_cocinas.PalletCocinasApp
+
+class ViewModelFactory(private val creator: () -> ViewModel) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T = creator() as T
+}
+
+val ComponentActivity.appContainer: AppContainer
+    get() = (application as PalletCocinasApp).container

--- a/app/src/main/java/com/escorial/pallet_cocinas/utils/Extensions.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/utils/Extensions.kt
@@ -1,7 +1,14 @@
 package com.escorial.pallet_cocinas.utils
 
 import retrofit2.HttpException
+import java.io.IOException
 
 fun HttpException.apiMessage(): String {
     return this.response()?.errorBody()?.string()?.replace("\"", "") ?: "Error desconocido"
+}
+
+fun Throwable.toUserMessage(): String = when (this) {
+    is HttpException -> "Error HTTP\n${apiMessage()}"
+    is IOException -> "Error de conexión."
+    else -> "Error al obtener datos."
 }

--- a/app/src/main/java/com/escorial/pallet_cocinas/viewmodel/AsociarProductoViewModel.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/viewmodel/AsociarProductoViewModel.kt
@@ -1,0 +1,249 @@
+package com.escorial.pallet_cocinas.viewmodel
+
+import androidx.core.content.edit
+import androidx.lifecycle.viewModelScope
+import com.escorial.pallet_cocinas.data.model.Pallet
+import com.escorial.pallet_cocinas.data.model.Product
+import com.escorial.pallet_cocinas.data.repository.PalletRepository
+import com.escorial.pallet_cocinas.data.repository.ProductRepository
+import com.escorial.pallet_cocinas.data.repository.SessionRepository
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.UUID
+
+data class AsociarProductoUiState(
+    val palletFieldEnabled: Boolean = true,
+    val productFieldEnabled: Boolean = false,
+    val productSpinnerEnabled: Boolean = true,
+    val spinnerSelection: Int = 0,
+    val isLoadingProduct: Boolean = false,
+    val isLoadingPallet: Boolean = false,
+    val isSubmitting: Boolean = false,
+    val username: String? = null,
+    val fullName: String? = null
+)
+
+sealed class AsociarProductoEvent {
+    data class ShowToast(val message: String) : AsociarProductoEvent()
+    data class FocusProductField(val clearFirst: Boolean) : AsociarProductoEvent()
+    object ProductsListChanged : AsociarProductoEvent()
+    object ResetFields : AsociarProductoEvent()
+}
+
+class AsociarProductoViewModel(
+    private val palletRepository: PalletRepository,
+    private val productRepository: ProductRepository,
+    private val sessionRepository: SessionRepository
+) : BaseViewModel() {
+
+    // Lista mutable compartida con ProductAdapter, igual que en el diseño original
+    // (el ViewModel es la fuente de verdad; las notificaciones de RecyclerView las
+    // dispara la Activity en respuesta a los eventos emitidos acá).
+    val productsList: ArrayList<Product> = ArrayList()
+
+    private var selectedProductType: String = ""
+
+    val initialPalletText: String
+    val initialProductText: String
+
+    private val _uiState = MutableStateFlow(AsociarProductoUiState())
+    val uiState: StateFlow<AsociarProductoUiState> = _uiState.asStateFlow()
+
+    private val _events = Channel<AsociarProductoEvent>(Channel.BUFFERED)
+    val events: Flow<AsociarProductoEvent> = _events.receiveAsFlow()
+
+    init {
+        val prefs = sessionRepository.preferences
+        initialPalletText = prefs.getString("palletText", "") ?: ""
+        initialProductText = prefs.getString("productText", "") ?: ""
+
+        val jsonList = prefs.getString("productsList", null)
+        if (!jsonList.isNullOrEmpty()) {
+            val type = object : TypeToken<ArrayList<Product>>() {}.type
+            val restoredList: ArrayList<Product>? = Gson().fromJson(jsonList, type)
+            if (restoredList != null) productsList.addAll(restoredList)
+        }
+
+        _uiState.update {
+            it.copy(
+                palletFieldEnabled = prefs.getBoolean("palletEditTextEnabled", true),
+                productFieldEnabled = prefs.getBoolean("productEditTextEnabled", false),
+                productSpinnerEnabled = prefs.getBoolean("productSpinnerEnabled", true),
+                spinnerSelection = prefs.getString("selectedProductIndex", "0")!!.toInt(),
+                username = sessionRepository.getUsername(),
+                fullName = sessionRepository.getFullName()
+            )
+        }
+    }
+
+    fun onProductTypeSelected(position: Int, label: String) {
+        selectedProductType = label
+        sessionRepository.preferences.edit { putString("selectedProductIndex", position.toString()) }
+        viewModelScope.launch { _events.send(AsociarProductoEvent.ShowToast("Seleccionaste: $label")) }
+    }
+
+    fun onProductTypeNothingSelected() {
+        viewModelScope.launch { _events.send(AsociarProductoEvent.ShowToast("No seleccionaste nada")) }
+    }
+
+    fun onPalletCodeSubmitted(codigo: String) {
+        if (_uiState.value.isLoadingPallet) return
+        safeLaunch(onLoadingChange = { loading -> _uiState.update { it.copy(isLoadingPallet = loading) } }) {
+            val pallet = palletRepository.getPalletWithProducts(codigo)
+            handlePallet(pallet)
+        }
+    }
+
+    private suspend fun handlePallet(pallet: Pallet) {
+        val products = pallet.Products
+        if (products != null && products.isNotEmpty()) {
+            productsList.addAll(products)
+            when (products.firstOrNull()?.type) {
+                "COCINA" -> _uiState.update { it.copy(spinnerSelection = 0, productSpinnerEnabled = false) }
+                "TERMOTANQUE" -> _uiState.update { it.copy(spinnerSelection = 1, productSpinnerEnabled = false) }
+            }
+            _events.send(AsociarProductoEvent.ProductsListChanged)
+        }
+        _uiState.update { it.copy(palletFieldEnabled = false, productFieldEnabled = true) }
+        _events.send(AsociarProductoEvent.FocusProductField(clearFirst = false))
+    }
+
+    fun onProductSerialSubmitted(serial: String) {
+        if (_uiState.value.isLoadingProduct) return
+        safeLaunch(onLoadingChange = { loading -> _uiState.update { it.copy(isLoadingProduct = loading) } }) {
+            if (serial.isEmpty()) {
+                _events.send(AsociarProductoEvent.FocusProductField(clearFirst = true))
+                throw IllegalStateException("Campo de producto vacío")
+            }
+            val tipo = when (selectedProductType) {
+                "COCINA" -> "COCINA"
+                "TERMO/CALEFON" -> "TERMOTANQUE"
+                "IMPORTADO" -> "IMPORTADO"
+                else -> throw IllegalStateException("Debe seleccionar un tipo de producto para continuar")
+            }
+            val product = productRepository.getProduct(serial, tipo)
+            handleProduct(product)
+        }
+    }
+
+    private suspend fun handleProduct(product: Product) {
+        if (!product.isAvailable) {
+            _events.send(AsociarProductoEvent.ShowToast("Producto ya palletizado"))
+            _events.send(AsociarProductoEvent.FocusProductField(clearFirst = true))
+            return
+        }
+        if (getNotDeletedProducts().count() == product.maxCantByPallet) {
+            _events.send(AsociarProductoEvent.ShowToast("Cantidad máxima de productos por pallet alcanzada"))
+            _events.send(AsociarProductoEvent.FocusProductField(clearFirst = true))
+            return
+        }
+        if (productsList.contains(product)) {
+            _events.send(AsociarProductoEvent.ShowToast("El producto ya fue pickeado"))
+            _events.send(AsociarProductoEvent.FocusProductField(clearFirst = true))
+            return
+        }
+        if (productsList.isNotEmpty() && productsList.last().productId != product.productId) {
+            _events.send(AsociarProductoEvent.ShowToast("Tipo de producto incorrecto"))
+            _events.send(AsociarProductoEvent.FocusProductField(clearFirst = true))
+            return
+        }
+        productsList.add(product)
+        _events.send(AsociarProductoEvent.ProductsListChanged)
+        _events.send(AsociarProductoEvent.FocusProductField(clearFirst = true))
+    }
+
+    fun deleteProduct(item: Product) {
+        val position = productsList.indexOf(item)
+        if (position == -1) return
+        productsList[position].deleted = true
+    }
+
+    fun restoreProduct(item: Product): Boolean {
+        val position = productsList.indexOf(item)
+        if (position == -1) return false
+        if (getNotDeletedProducts().count() >= item.maxCantByPallet) {
+            viewModelScope.launch {
+                _events.send(AsociarProductoEvent.ShowToast("Cantidad máxima de productos por pallet alcanzada"))
+            }
+            return false
+        }
+        productsList[position].deleted = false
+        return true
+    }
+
+    fun onSubmit(codigo: String) {
+        if (_uiState.value.isSubmitting) return
+        if (productsList.isEmpty()) return
+        if (getNotDeletedProducts().count() != productsList.first().maxCantByPallet) {
+            viewModelScope.launch { _events.send(AsociarProductoEvent.ShowToast("Debe asociar todos los productos")) }
+            return
+        }
+        val palletPost = Pallet(
+            id = UUID.randomUUID(),
+            descripcion = "",
+            fecha_alta = "",
+            codigo = codigo,
+            transferir = false,
+            Products = productsList,
+            Usuario = sessionRepository.getUsername(default = "") ?: ""
+        )
+        safeLaunch(onLoadingChange = { loading -> _uiState.update { it.copy(isSubmitting = loading) } }) {
+            val response = productRepository.asociarProductos(palletPost)
+            if (response.isSuccessful) {
+                _events.send(AsociarProductoEvent.ShowToast("Productos asociados al pallet"))
+                resetState()
+                _events.send(AsociarProductoEvent.ResetFields)
+            } else {
+                val error = response.errorBody()?.string()
+                _events.send(AsociarProductoEvent.ShowToast("Error al asociar productos al pallet. $error"))
+            }
+        }
+    }
+
+    fun onChangePalletClicked() {
+        resetState()
+        viewModelScope.launch { _events.send(AsociarProductoEvent.ResetFields) }
+    }
+
+    private fun resetState() {
+        productsList.clear()
+        val prefs = sessionRepository.preferences
+        _uiState.update {
+            it.copy(
+                palletFieldEnabled = true,
+                productFieldEnabled = false,
+                productSpinnerEnabled = true,
+                spinnerSelection = prefs.getString("selectedProductIndex", "0")!!.toInt()
+            )
+        }
+        prefs.edit {
+            remove("palletText")
+            remove("productText")
+            remove("productsList")
+        }
+    }
+
+    fun onPause(palletText: String, productText: String) {
+        val state = _uiState.value
+        sessionRepository.preferences.edit {
+            putString("palletText", palletText)
+            putString("productText", productText)
+            putBoolean("palletEditTextEnabled", state.palletFieldEnabled)
+            putBoolean("productEditTextEnabled", state.productFieldEnabled)
+            putBoolean("productSpinnerEnabled", state.productSpinnerEnabled)
+            putString("productsList", Gson().toJson(productsList))
+        }
+    }
+
+    fun logout() = sessionRepository.logout()
+
+    private fun getNotDeletedProducts(): List<Product> = productsList.filter { !it.deleted }
+}

--- a/app/src/main/java/com/escorial/pallet_cocinas/viewmodel/BaseViewModel.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/viewmodel/BaseViewModel.kt
@@ -1,0 +1,33 @@
+package com.escorial.pallet_cocinas.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.escorial.pallet_cocinas.utils.toUserMessage
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+
+abstract class BaseViewModel : ViewModel() {
+
+    private val _errorEvents = Channel<String>(Channel.BUFFERED)
+    val errorEvents: Flow<String> = _errorEvents.receiveAsFlow()
+
+    protected fun safeLaunch(
+        onLoadingChange: (Boolean) -> Unit = {},
+        block: suspend CoroutineScope.() -> Unit
+    ): Job = viewModelScope.launch {
+        onLoadingChange(true)
+        try {
+            block()
+        } catch (t: Throwable) {
+            if (t is CancellationException) throw t
+            _errorEvents.send(t.toUserMessage())
+        } finally {
+            onLoadingChange(false)
+        }
+    }
+}

--- a/app/src/main/java/com/escorial/pallet_cocinas/viewmodel/ConfigViewModel.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/viewmodel/ConfigViewModel.kt
@@ -1,0 +1,33 @@
+package com.escorial.pallet_cocinas.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.escorial.pallet_cocinas.data.repository.ConfigRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+data class ConfigUiState(
+    val isUnlocked: Boolean = false,
+    val apiUrl: String = ""
+)
+
+class ConfigViewModel(private val configRepository: ConfigRepository) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ConfigUiState())
+    val uiState: StateFlow<ConfigUiState> = _uiState.asStateFlow()
+
+    fun validatePassword(password: String): Boolean {
+        if (password != CONTRASEÑA_CORRECTA) return false
+        _uiState.update { it.copy(isUnlocked = true, apiUrl = configRepository.getApiUrl()) }
+        return true
+    }
+
+    fun saveApiUrl(url: String) {
+        configRepository.setApiUrl(url)
+    }
+
+    private companion object {
+        const val CONTRASEÑA_CORRECTA = "Aria9278"
+    }
+}

--- a/app/src/main/java/com/escorial/pallet_cocinas/viewmodel/ExpedicionViewModel.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/viewmodel/ExpedicionViewModel.kt
@@ -1,0 +1,25 @@
+package com.escorial.pallet_cocinas.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.escorial.pallet_cocinas.data.repository.SessionRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+data class ExpedicionUiState(
+    val username: String?,
+    val fullName: String?
+)
+
+class ExpedicionViewModel(private val sessionRepository: SessionRepository) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(
+        ExpedicionUiState(
+            username = sessionRepository.getUsername(),
+            fullName = sessionRepository.getFullName()
+        )
+    )
+    val uiState: StateFlow<ExpedicionUiState> = _uiState.asStateFlow()
+
+    fun logout() = sessionRepository.logout()
+}

--- a/app/src/main/java/com/escorial/pallet_cocinas/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/viewmodel/LoginViewModel.kt
@@ -1,0 +1,50 @@
+package com.escorial.pallet_cocinas.viewmodel
+
+import androidx.lifecycle.viewModelScope
+import com.escorial.pallet_cocinas.data.repository.LoginRepository
+import com.escorial.pallet_cocinas.data.repository.SessionRepository
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class LoginUiState(val isLoading: Boolean = false)
+
+sealed class LoginNavEvent {
+    data class ToMain(val bypass: Boolean) : LoginNavEvent()
+}
+
+class LoginViewModel(
+    private val loginRepository: LoginRepository,
+    private val sessionRepository: SessionRepository
+) : BaseViewModel() {
+
+    private val _uiState = MutableStateFlow(LoginUiState())
+    val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
+
+    private val _navEvents = Channel<LoginNavEvent>(Channel.BUFFERED)
+    val navEvents: Flow<LoginNavEvent> = _navEvents.receiveAsFlow()
+
+    val initialNavEvent: LoginNavEvent? = run {
+        if (!sessionRepository.isLoggedIn()) return@run null
+        val loggedUser = sessionRepository.getUsername(default = "")
+        LoginNavEvent.ToMain(bypass = loggedUser == "expedicion")
+    }
+
+    fun login(username: String, password: String) {
+        if (username == "expedicion" && password == "expedicion") {
+            sessionRepository.saveSession("expedicion", "Expedicion")
+            viewModelScope.launch { _navEvents.send(LoginNavEvent.ToMain(bypass = true)) }
+            return
+        }
+        safeLaunch(onLoadingChange = { loading -> _uiState.update { it.copy(isLoading = loading) } }) {
+            val loginResult = loginRepository.login(username, password) ?: return@safeLaunch
+            sessionRepository.saveSession(loginResult.usuario_sistema, loginResult.nombre)
+            _navEvents.send(LoginNavEvent.ToMain(bypass = false))
+        }
+    }
+}

--- a/app/src/main/java/com/escorial/pallet_cocinas/viewmodel/PickeoPalletViewModel.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/viewmodel/PickeoPalletViewModel.kt
@@ -1,0 +1,123 @@
+package com.escorial.pallet_cocinas.viewmodel
+
+import androidx.lifecycle.viewModelScope
+import com.escorial.pallet_cocinas.data.model.Pallet
+import com.escorial.pallet_cocinas.data.repository.ExpedicionRepository
+import com.escorial.pallet_cocinas.data.repository.SessionRepository
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class PickeoPalletUiState(
+    val tipo: String,
+    val isLoading: Boolean = false,
+    val username: String? = null,
+    val fullName: String? = null
+)
+
+sealed class PickeoPalletEvent {
+    data class ShowToast(val message: String) : PickeoPalletEvent()
+    object ListChanged : PickeoPalletEvent()
+}
+
+class PickeoPalletViewModel(
+    private val expedicionRepository: ExpedicionRepository,
+    private val sessionRepository: SessionRepository,
+    tipo: String
+) : BaseViewModel() {
+
+    val palletsList: ArrayList<Pallet> = ArrayList()
+
+    private val _uiState = MutableStateFlow(
+        PickeoPalletUiState(
+            tipo = tipo,
+            username = sessionRepository.getUsername(),
+            fullName = sessionRepository.getFullName()
+        )
+    )
+    val uiState: StateFlow<PickeoPalletUiState> = _uiState.asStateFlow()
+
+    private val _events = Channel<PickeoPalletEvent>(Channel.BUFFERED)
+    val events: Flow<PickeoPalletEvent> = _events.receiveAsFlow()
+
+    private var lastDeletedItem: Pallet? = null
+    private var lastDeletedItemPosition: Int = -1
+
+    fun buscarPallet(codigo: String) {
+        if (_uiState.value.isLoading) return
+        safeLaunch(onLoadingChange = { loading -> _uiState.update { it.copy(isLoading = loading) } }) {
+            val pallet = expedicionRepository.buscarPallet(codigo)
+            handlePallet(pallet)
+        }
+    }
+
+    private suspend fun handlePallet(pallet: Pallet) {
+        try {
+            val products = pallet.Products ?: return
+            if (products.isEmpty()) {
+                _events.send(PickeoPalletEvent.ShowToast("El pallet no tiene productos asociados."))
+                return
+            }
+            if (palletsList.contains(pallet)) {
+                _events.send(PickeoPalletEvent.ShowToast("Pallet ya pickeado."))
+                return
+            }
+            if (_uiState.value.tipo == "transferir" && pallet.transferir) {
+                _events.send(PickeoPalletEvent.ShowToast("Pallet ya transferido."))
+                return
+            }
+            palletsList.add(pallet)
+        } finally {
+            _events.send(PickeoPalletEvent.ListChanged)
+        }
+    }
+
+    fun eliminarPallet(position: Int) {
+        if (position !in palletsList.indices) return
+        lastDeletedItem = palletsList[position]
+        lastDeletedItemPosition = position
+        palletsList.removeAt(position)
+    }
+
+    fun restaurarUltimoEliminado(): Int? {
+        val item = lastDeletedItem
+        val position = lastDeletedItemPosition
+        if (item == null || position == -1) return null
+        palletsList.add(position, item)
+        lastDeletedItem = null
+        lastDeletedItemPosition = -1
+        return position
+    }
+
+    fun confirmarAccion() {
+        if (_uiState.value.isLoading) {
+            viewModelScope.launch { _events.send(PickeoPalletEvent.ShowToast("Ya hay una transferencia en curso.")) }
+            return
+        }
+        if (palletsList.isEmpty()) {
+            viewModelScope.launch { _events.send(PickeoPalletEvent.ShowToast("No hay pallets seleccionados.")) }
+            return
+        }
+        val tipo = _uiState.value.tipo
+        safeLaunch(onLoadingChange = { loading -> _uiState.update { it.copy(isLoading = loading) } }) {
+            val response = when (tipo) {
+                "transferir" -> expedicionRepository.transferirPallets(palletsList)
+                "desasociar" -> expedicionRepository.desasociarPallets(palletsList)
+                else -> return@safeLaunch
+            }
+            if (response.isSuccessful) {
+                val message = if (tipo == "transferir") "Transferencia" else "Desasociación"
+                palletsList.clear()
+                _events.send(PickeoPalletEvent.ShowToast("$message exitosa."))
+                _events.send(PickeoPalletEvent.ListChanged)
+            }
+        }
+    }
+
+    fun logout() = sessionRepository.logout()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ material = "1.12.0"
 activity = "1.10.1"
 constraintlayout = "2.2.1"
 recyclerview = "1.4.0"
+lifecycle = "2.8.7"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -21,6 +22,8 @@ material = { group = "com.google.android.material", name = "material", version.r
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version.ref = "recyclerview" }
+androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Resumen
- Introduce `ViewModel` + `StateFlow` para las 5 pantallas (Login, AsociarProducto, Expedicion, PickeoPallet, Config), sacando toda la lógica de negocio y el manejo de estado de las Activities.
- Agrega repositorios para todos los endpoints (`LoginRepository`, `ProductRepository`, `ExpedicionRepository`, `SessionRepository`, `ConfigRepository`) — antes solo existía `PalletRepository`.
- DI manual sin framework (`AppContainer` + `ViewModelFactory` genérica), sin agregar Hilt/Koin.
- Centraliza el manejo de errores de red (antes duplicado casi textual en 4 lugares) en `BaseViewModel.safeLaunch()` + `Throwable.toUserMessage()`.
- Reemplaza todos los `findViewById` por ViewBinding (Activities, `TopBar`, `PalletAdapter`, `ProductAdapter`).
- Mueve la capa de datos a `data/remote`, `data/model`, `data/repository`.

## Fuera de alcance (a propósito)
- No se agregaron tests automatizados.
- No se limpiaron las dependencias sueltas de `build.gradle.kts` (Retrofit/Gson/coroutines siguen como string literal), salvo las 2 nuevas de `lifecycle-viewmodel-ktx`/`lifecycle-runtime-ktx` agregadas al catálogo.
- No se corrigieron los 2 hallazgos de seguridad preexistentes (password hardcodeada `"Aria9278"` en `ConfigViewModel`, bypass de login `"expedicion"/"expedicion"` en `LoginViewModel`) — se preservó su comportamiento exacto, solo cambiaron de archivo.

## Decisión de persistencia de estado
`AsociarProductoActivity` persistía su estado (pallet/producto en curso, lista de productos pickeados) en `SharedPreferences` + `Gson` para sobrevivir tanto rotación como proceso muerto. Con el `ViewModel`, la rotación ya no necesita I/O (el `ViewModel` sobrevive en memoria). Para proceso muerto, el `ViewModel` restaura ese mismo estado desde `SharedPreferences` en su `init{}`, y la escritura sigue ocurriendo solo en `onPause()`, igual que antes.

## Test plan
- [x] `.\gradlew.bat compileDebugKotlin` — compila sin errores tras cada paso de la migración.
- [x] `.\gradlew.bat assembleDebug` — build completo exitoso.
- [x] `.\gradlew.bat lint` — sin errores.
- [x] `.\gradlew.bat testDebugUnitTest` — pasa (solo tests template existentes).
- [ ] Prueba manual en dispositivo/emulador (no había uno disponible en este entorno): login normal + bypass `expedicion`/`expedicion`, asociar productos (casos ok / ya palletizado / cantidad máxima / tipo inconsistente / swipe-undo), pickeo de pallets en modo transferir y desasociar, cambio de URL desde Config, y rotación/"Don't keep activities" en AsociarProducto para confirmar que no se pierde el estado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)