### PR TITLE
fix: flujo automatico de focos al pickear productos

### DIFF
--- a/app/src/main/java/com/escorial/pallet_cocinas/AsociarProductoActivity.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/AsociarProductoActivity.kt
@@ -193,11 +193,12 @@ class AsociarProductoActivity : AppCompatActivity() {
         val ean = eanEditText.text.toString()
         if (ean.isEmpty()) {
             Toast.makeText(this@AsociarProductoActivity, "Debe escanear el EAN", Toast.LENGTH_LONG).show()
-            eanEditText.requestFocus()
+            // Se posterga para no ser pisado por el clearFocus() síncrono del listener.
+            eanEditText.post { eanEditText.requestFocus() }
             return
         }
         // El EAN se enviará al hacer el pickeo del serial; no se fija currentEan todavía.
-        productEditText.requestFocus()
+        productEditText.post { productEditText.requestFocus() }
     }
 
     private fun coroutineProduct() {
@@ -238,12 +239,15 @@ class AsociarProductoActivity : AppCompatActivity() {
             } catch (h: HttpException) {
                 Toast.makeText(this@AsociarProductoActivity, "Error HTTP\n${h.apiMessage()}", Toast.LENGTH_LONG).show()
                 Log.d("API_ERROR", "Error HTTP. ${h.message}")
+                productEditText.requestFocus()
             } catch (i: IOException) {
                 Toast.makeText(this@AsociarProductoActivity, "Error de conexion.", Toast.LENGTH_LONG).show()
                 Log.d("API_ERROR", "Error de conexion. ${i.message}")
+                productEditText.requestFocus()
             } catch (e: Exception) {
                 Toast.makeText(this@AsociarProductoActivity, "Error al obtener datos.", Toast.LENGTH_LONG).show()
                 Log.d("API_ERROR", "Error al obtener datos. ${e.message}")
+                productEditText.requestFocus()
             }
             finally {
                 progressBar.visibility = View.GONE
@@ -302,10 +306,13 @@ class AsociarProductoActivity : AppCompatActivity() {
                 handlePallet(pallet)
             } catch (h: HttpException) {
                 Toast.makeText(this@AsociarProductoActivity, "Error HTTP.\n${h.apiMessage()}", Toast.LENGTH_LONG).show()
+                palletEditText.requestFocus()
             } catch (i: IOException) {
                 Toast.makeText(this@AsociarProductoActivity, "Error de conexion.\n${i.message}", Toast.LENGTH_LONG).show()
+                palletEditText.requestFocus()
             } catch (e: Exception) {
                 Toast.makeText(this@AsociarProductoActivity, "Error al obtener datos.\n${e.message}", Toast.LENGTH_LONG).show()
+                palletEditText.requestFocus()
             } finally {
                 progressBar.visibility = View.GONE
                 isPalletRequestInProgress = false
@@ -353,8 +360,10 @@ class AsociarProductoActivity : AppCompatActivity() {
             eanEditText.isEnabled = true
             eanEditText.text.clear()
             currentEan = null
+            eanEditText.requestFocus()
+        } else {
+            productEditText.requestFocus()
         }
-        productEditText.requestFocus()
     }
 
     private fun submit() {


### PR DESCRIPTION
## Contexto
Al pickear productos con la lectora de código de barras, el operario tenía que tocar la pantalla porque el foco no avanzaba correctamente entre los campos. En particular, para pallets **IMPORTADO** el foco saltaba directo del pallet a la serie, salteando el campo EAN.

## Cambios (`AsociarProductoActivity.kt`)
- **`handlePallet()`**: tras cargar el pallet, el foco va al **EAN** si el tipo es IMPORTADO, o a **serie** si es cocina/termo/calefón. Secuencias:
  - Cocina/Termo/Calefón: pallet → serie (se mantiene en serie).
  - IMPORTADO: pallet → EAN → serie (se mantiene en serie; el EAN se pide una vez por pallet).
- **`handleEan()`**: los `requestFocus()` se difieren con `post{}` para que no los pise el `clearFocus()` síncrono del listener del lector. EAN vacío mantiene el foco en EAN; EAN no vacío salta a serie de forma confiable.
- **Errores de red**: al validar pallet → el foco vuelve a pallet; al pickear serie → el foco vuelve a serie.
- El teclado virtual no reaparece en ningún salto de foco.

## Verificación
- `compileDebugKotlin`: BUILD SUCCESSFUL.
- Revisión por inspección: los 10 criterios de aceptación pasan, sin regresiones.
- Pendiente: confirmación en device con lectora física (queda a cargo del usuario).

🤖 Generated with [Claude Code](https://claude.com/claude-code)