### PR TITLE
feat: configuracion de URL de API en primer arranque + health check + acceso in-app

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.escorial.pallet_cocinas"
         minSdk = 28
         targetSdk = 35
-        versionCode = 20364
-        versionName = "1.3.1-dev"
+        versionCode = 20365
+        versionName = "1.3.2-dev"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/escorial/pallet_cocinas/ApiClient.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/ApiClient.kt
@@ -1,16 +1,23 @@
 package com.escorial.pallet_cocinas
 
 import android.content.Context
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.io.IOException
 
 object ApiClient {
+
+    private const val DEFAULT_URL = "http://0.0.0.0"
 
     private var retrofit: Retrofit? = null
 
     fun getApiService(context: Context): ApiService {
         val prefs = context.getSharedPreferences("configuracion", Context.MODE_PRIVATE)
-        val baseUrl = prefs.getString("api_url", "http://0.0.0.0")!!
+        val baseUrl = prefs.getString("api_url", DEFAULT_URL)!!
 
         if (retrofit == null || retrofit?.baseUrl().toString() != baseUrl) {
             retrofit = Retrofit.Builder()
@@ -20,5 +27,39 @@ object ApiClient {
         }
 
         return retrofit!!.create(ApiService::class.java)
+    }
+
+    fun isConfigured(context: Context): Boolean {
+        val prefs = context.getSharedPreferences("configuracion", Context.MODE_PRIVATE)
+        val baseUrl = prefs.getString("api_url", DEFAULT_URL)?.trim()
+        return !baseUrl.isNullOrEmpty() && baseUrl != DEFAULT_URL
+    }
+
+    suspend fun checkHealth(baseUrl: String): Boolean = withContext(Dispatchers.IO) {
+        // Retrofit descartable: no toca el singleton ni persiste nada.
+        val service = try {
+            Retrofit.Builder()
+                .baseUrl(baseUrl)
+                .addConverterFactory(GsonConverterFactory.create())
+                .build()
+                .create(ApiService::class.java)
+        } catch (e: IllegalArgumentException) {
+            return@withContext false
+        }
+
+        try {
+            service.getPallet("0")
+            true
+        } catch (h: HttpException) {
+            // El servidor respondió (aunque con error HTTP): la URL es válida.
+            true
+        } catch (e: IOException) {
+            false
+        } catch (e: CancellationException) {
+            // Re-lanzar para no romper structured concurrency si se cancela la corrutina.
+            throw e
+        } catch (e: Exception) {
+            false
+        }
     }
 }

--- a/app/src/main/java/com/escorial/pallet_cocinas/AsociarProductoActivity.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/AsociarProductoActivity.kt
@@ -53,9 +53,10 @@ class AsociarProductoActivity : AppCompatActivity() {
     lateinit var progressBar: ProgressBar
     lateinit var changePalletButton: AppCompatImageButton
 
-    lateinit var api: ApiService
+    // Getters para releer siempre la URL vigente (puede cambiar vía config in-app).
+    val api get() = ApiClient.getApiService(this)
 
-    lateinit var palletRepository: PalletRepository
+    val palletRepository get() = PalletRepository(api)
 
     var productsList: ArrayList<Product> = ArrayList()
     lateinit var pickeadosTextView: TextView
@@ -155,6 +156,10 @@ class AsociarProductoActivity : AppCompatActivity() {
         topBar.setOnLogoutClickListener  {
             logout()
             Toast.makeText(this@AsociarProductoActivity, "Logout", Toast.LENGTH_SHORT).show()
+        }
+        topBar.setConfigButtonVisibility(true)
+        topBar.setOnConfigClickListener {
+            startActivity(Intent(this@AsociarProductoActivity, ConfigActivity::class.java))
         }
 
         productEditText.setOnEditorActionListener(createEnterListener("product"))
@@ -419,9 +424,6 @@ class AsociarProductoActivity : AppCompatActivity() {
     private fun loadControls() {
         Log.d("LoadControls", "Loading controls")
         prefs = getSharedPreferences("user_prefs", MODE_PRIVATE)
-
-        api = ApiClient.getApiService(this)
-        palletRepository = PalletRepository(api)
 
         progressBar = findViewById(R.id.progressBar)
         palletEditText = findViewById(R.id.palletEditText)

--- a/app/src/main/java/com/escorial/pallet_cocinas/ConfigActivity.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/ConfigActivity.kt
@@ -6,13 +6,22 @@ import android.view.View
 import android.widget.Button
 import android.widget.EditText
 import android.widget.LinearLayout
+import android.widget.ProgressBar
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatImageButton
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
 
 class ConfigActivity : AppCompatActivity() {
 
+    companion object {
+        const val EXTRA_FIRST_RUN = "first_run"
+    }
+
     private val contraseñaCorrecta = "Aria9278"
+
+    private val urlDefault = "http://0.0.0.0"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -26,11 +35,23 @@ class ConfigActivity : AppCompatActivity() {
         val etApiUrl = findViewById<EditText>(R.id.etApiUrl)
         val btnGuardar = findViewById<Button>(R.id.btnGuardar)
         val btnCancelar = findViewById<AppCompatImageButton>(R.id.btnCancelar)
+        val progressBar = findViewById<ProgressBar>(R.id.progressBarConfig)
 
         val prefs = getSharedPreferences("configuracion", Context.MODE_PRIVATE)
 
+        val firstRun = intent.getBooleanExtra(EXTRA_FIRST_RUN, false)
+
         // Ocultar el layout de configuración hasta validar
         layoutConfig.visibility = View.GONE
+
+        if (firstRun) {
+            // Primer arranque: sin contraseña y sin poder salir hasta configurar.
+            layoutPassword.visibility = View.GONE
+            layoutConfig.visibility = View.VISIBLE
+            btnCancelar.visibility = View.GONE
+            val urlActual = prefs.getString("api_url", "") ?: ""
+            etApiUrl.setText(if (urlActual == urlDefault) "" else urlActual)
+        }
 
         btnValidar.setOnClickListener {
             if (etPassword.text.toString() == contraseñaCorrecta) {
@@ -43,14 +64,46 @@ class ConfigActivity : AppCompatActivity() {
         }
 
         btnGuardar.setOnClickListener {
-            val nuevaUrl = etApiUrl.text.toString()
-            prefs.edit().putString("api_url", nuevaUrl).apply()
-            Toast.makeText(this, "Configuración guardada", Toast.LENGTH_SHORT).show()
-            finish()
+            val nuevaUrl = etApiUrl.text.toString().trim()
+            if (nuevaUrl.isEmpty() ||
+                !(nuevaUrl.startsWith("http://") || nuevaUrl.startsWith("https://"))
+            ) {
+                Toast.makeText(
+                    this,
+                    "Ingrese una URL válida (http:// o https://)",
+                    Toast.LENGTH_SHORT
+                ).show()
+                return@setOnClickListener
+            }
+
+            progressBar.visibility = View.VISIBLE
+            btnGuardar.isEnabled = false
+
+            lifecycleScope.launch {
+                val ok = ApiClient.checkHealth(nuevaUrl)
+                if (ok) {
+                    prefs.edit().putString("api_url", nuevaUrl).apply()
+                    Toast.makeText(this@ConfigActivity, "Configuración guardada", Toast.LENGTH_SHORT).show()
+                    finish()
+                } else {
+                    Toast.makeText(this@ConfigActivity, "La URL de la API es incorrecta", Toast.LENGTH_LONG).show()
+                    progressBar.visibility = View.GONE
+                    btnGuardar.isEnabled = true
+                }
+            }
         }
 
         btnCancelar.setOnClickListener {
             finish()
         }
+    }
+
+    override fun onBackPressed() {
+        // En primer arranque el usuario no puede salir sin configurar la URL.
+        if (intent.getBooleanExtra(EXTRA_FIRST_RUN, false)) {
+            Toast.makeText(this, "Debe configurar la URL de la API", Toast.LENGTH_SHORT).show()
+            return
+        }
+        super.onBackPressed()
     }
 }

--- a/app/src/main/java/com/escorial/pallet_cocinas/ExpedicionActivity.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/ExpedicionActivity.kt
@@ -43,6 +43,10 @@ class ExpedicionActivity : AppCompatActivity() {
             logout()
             Toast.makeText(this@ExpedicionActivity, "Logout", Toast.LENGTH_SHORT).show()
         }
+        topBar.setConfigButtonVisibility(true)
+        topBar.setOnConfigClickListener {
+            startActivity(Intent(this@ExpedicionActivity, ConfigActivity::class.java))
+        }
         btnTransferir = findViewById(R.id.btnTransferir)
         btnDesasociar = findViewById(R.id.btnDesasociar)
         btnDesasociar.setOnClickListener { startPickeoPalletActivity("desasociar") }

--- a/app/src/main/java/com/escorial/pallet_cocinas/LoginActivity.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/LoginActivity.kt
@@ -35,6 +35,14 @@ class LoginActivity : AppCompatActivity() {
 
         loadControls()
 
+        if (!ApiClient.isConfigured(this)) {
+            startActivity(
+                Intent(this, ConfigActivity::class.java)
+                    .putExtra(ConfigActivity.EXTRA_FIRST_RUN, true)
+            )
+            return
+        }
+
         val isLoggedIn = sharedPreferences.getBoolean("isLoggedIn", false)
 
         if (isLoggedIn) {

--- a/app/src/main/java/com/escorial/pallet_cocinas/PickeoPalletActivity.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/PickeoPalletActivity.kt
@@ -38,9 +38,10 @@ class PickeoPalletActivity : AppCompatActivity() {
     lateinit var palletEditText: EditText
     lateinit var palletsRecyclerView: RecyclerView
     lateinit var progressBar: ProgressBar
-    lateinit var api: ApiService
+    // Getters para releer siempre la URL vigente (puede cambiar vía config in-app).
+    val api get() = ApiClient.getApiService(this)
     var palletsList: ArrayList<Pallet> = ArrayList()
-    lateinit var palletRepository: PalletRepository
+    val palletRepository get() = PalletRepository(api)
     lateinit var palletAdapter: PalletAdapter
     lateinit var tipo: String
 
@@ -127,10 +128,12 @@ class PickeoPalletActivity : AppCompatActivity() {
             logout()
             Toast.makeText(this@PickeoPalletActivity, "Logout", Toast.LENGTH_SHORT).show()
         }
-        api = ApiClient.getApiService(this)
+        topBar.setConfigButtonVisibility(true)
+        topBar.setOnConfigClickListener {
+            startActivity(Intent(this@PickeoPalletActivity, ConfigActivity::class.java))
+        }
         lblTitle = findViewById(R.id.lblTitle)
         lblTitle.text = lblTitle.text.toString().replace("{type}", if(tipo == "transferir") "Transferencia" else "Desasociación")
-        palletRepository = PalletRepository(api)
         progressBar = findViewById(R.id.progressBar)
         transferirButton = findViewById(R.id.btnTransferir)
         transferirButton.setOnClickListener {

--- a/app/src/main/java/com/escorial/pallet_cocinas/TopBar.kt
+++ b/app/src/main/java/com/escorial/pallet_cocinas/TopBar.kt
@@ -14,6 +14,7 @@ class TopBar(context: Context, attrs: AttributeSet) : LinearLayout(context, attr
     private val usernameLabel: TextView
     private val completeNameLabel: TextView
     private val logoutButton: View
+    private val configButton: View
 
     init {
         LayoutInflater.from(context).inflate(R.layout.top_bar, this, true)
@@ -21,6 +22,7 @@ class TopBar(context: Context, attrs: AttributeSet) : LinearLayout(context, attr
         usernameLabel = findViewById(R.id.usernameLabel)
         completeNameLabel = findViewById(R.id.completeNameLabel)
         logoutButton = findViewById(R.id.logoutButton)
+        configButton = findViewById(R.id.configButton)
     }
 
     fun setUserInfo(username: String?, completeName: String?) {
@@ -37,5 +39,13 @@ class TopBar(context: Context, attrs: AttributeSet) : LinearLayout(context, attr
 
     fun setOnLogoutClickListener(listener: OnClickListener) {
         logoutButton.setOnClickListener(listener)
+    }
+
+    fun setConfigButtonVisibility(isVisible: Boolean) {
+        configButton.isVisible = isVisible
+    }
+
+    fun setOnConfigClickListener(listener: OnClickListener) {
+        configButton.setOnClickListener(listener)
     }
 }

--- a/app/src/main/res/layout/activity_config.xml
+++ b/app/src/main/res/layout/activity_config.xml
@@ -81,6 +81,12 @@
                 android:text="Guardar"
                 android:layout_marginTop="16dp"/>
 
+            <ProgressBar
+                android:id="@+id/progressBarConfig"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:visibility="gone" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/activity_config.xml
+++ b/app/src/main/res/layout/activity_config.xml
@@ -1,105 +1,160 @@
+<?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@drawable/login_background"
+    android:fillViewport="true">
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
+        android:gravity="center"
         android:orientation="vertical"
-        android:padding="24dp">
+        android:padding="20dp">
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:textSize="24dp"
-            android:layout_marginBottom="20dp"
-            android:text="Configuracion"
-            />
-
-        <!-- Admin contraseña -->
-        <LinearLayout
-            android:id="@+id/layoutPassword"
+        <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            app:cardBackgroundColor="@android:color/white"
+            app:cardCornerRadius="20dp"
+            app:cardElevation="6dp">
 
-            <EditText
-                android:id="@+id/etPassword"
-                android:layout_width="match_parent"
-                android:layout_height="35dp"
-                android:ems="10"
-                android:paddingLeft="10dp"
-                android:layout_marginBottom="5dp"
-                android:background="@drawable/rounded_input_text"
-                android:hint="Contraseña"
-                android:inputType="textPassword" />
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:text="Ingresar Contraseña para acceder a la Configuracion"
-                />
-
-            <Button
-                android:id="@+id/btnValidar"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="20dp"
-                android:text="Acceder"
-                android:layout_marginTop="16dp"/>
-        </LinearLayout>
+                android:orientation="vertical"
+                android:padding="24dp">
 
-        <!-- Config -->
-        <LinearLayout
-            android:id="@+id/layoutConfig"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
+                <!-- Botón cerrar (oculto en primer arranque) -->
+                <androidx.appcompat.widget.AppCompatImageButton
+                    android:id="@+id/btnCancelar"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:layout_gravity="end"
+                    android:background="@drawable/remove_button_bk"
+                    android:contentDescription="Cerrar"
+                    android:scaleType="center"
+                    android:src="@drawable/ic_close_pallet_foreground"
+                    android:tint="@android:color/white" />
 
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:text="URL de la API"
-                />
+                <!-- Logo -->
+                <ImageView
+                    android:id="@+id/imageViewLogo"
+                    android:layout_width="match_parent"
+                    android:layout_height="90dp"
+                    android:layout_marginTop="4dp"
+                    android:contentDescription="Logo"
+                    android:src="@drawable/login_logo" />
 
-            <EditText
-                android:id="@+id/etApiUrl"
-                android:layout_width="match_parent"
-                android:layout_height="35dp"
-                android:ems="10"
-                android:paddingLeft="10dp"
-                android:background="@drawable/rounded_input_text"
-                android:hint="URL de la API"
-                android:inputType="textUri"
-                android:layout_marginTop="5dp" />
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    android:layout_marginTop="16dp"
+                    android:text="Configuración"
+                    android:textColor="@color/colorPrimary"
+                    android:textSize="24sp"
+                    android:textStyle="bold" />
 
-            <Button
-                android:id="@+id/btnGuardar"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="20dp"
-                android:text="Guardar"
-                android:layout_marginTop="16dp"/>
+                <!-- Admin contraseña -->
+                <LinearLayout
+                    android:id="@+id/layoutPassword"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
 
-            <ProgressBar
-                android:id="@+id/progressBarConfig"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:visibility="gone" />
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="24dp"
+                        android:text="Ingresá la contraseña para acceder a la configuración"
+                        android:textColor="#666666"
+                        android:textSize="14sp" />
 
-        </LinearLayout>
+                    <EditText
+                        android:id="@+id/etPassword"
+                        android:layout_width="match_parent"
+                        android:layout_height="50dp"
+                        android:layout_marginTop="12dp"
+                        android:background="@drawable/input_text_login"
+                        android:hint="Contraseña"
+                        android:inputType="textPassword"
+                        android:paddingStart="18dp"
+                        android:paddingEnd="18dp" />
 
-        <androidx.appcompat.widget.AppCompatImageButton
-            android:id="@+id/btnCancelar"
-            android:layout_width="35dp"
-            android:layout_height="35dp"
-            android:layout_margin="4dp"
-            android:layout_gravity="center"
-            android:background="@drawable/remove_button_bk"
-            android:src="@drawable/ic_close_pallet_foreground"
-            android:scaleType="center"
-            android:tint="@android:color/white" />
+                    <Button
+                        android:id="@+id/btnValidar"
+                        style="@style/Widget.MaterialComponents.Button"
+                        android:layout_width="match_parent"
+                        android:layout_height="50dp"
+                        android:layout_marginTop="20dp"
+                        android:backgroundTint="@color/colorPrimary"
+                        android:text="Acceder"
+                        android:textColor="@android:color/white"
+                        app:cornerRadius="12dp" />
+                </LinearLayout>
+
+                <!-- Config URL -->
+                <LinearLayout
+                    android:id="@+id/layoutConfig"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="24dp"
+                        android:text="URL de la API"
+                        android:textColor="@color/colorPrimary"
+                        android:textSize="16sp"
+                        android:textStyle="bold" />
+
+                    <EditText
+                        android:id="@+id/etApiUrl"
+                        android:layout_width="match_parent"
+                        android:layout_height="50dp"
+                        android:layout_marginTop="12dp"
+                        android:background="@drawable/input_text_login"
+                        android:hint="http://192.168.1.1:8080"
+                        android:inputType="textUri"
+                        android:maxLines="1"
+                        android:paddingStart="18dp"
+                        android:paddingEnd="18dp" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:text="Ingresá la dirección completa del servidor, incluyendo http:// o https://"
+                        android:textColor="#666666"
+                        android:textSize="13sp" />
+
+                    <Button
+                        android:id="@+id/btnGuardar"
+                        style="@style/Widget.MaterialComponents.Button"
+                        android:layout_width="match_parent"
+                        android:layout_height="50dp"
+                        android:layout_marginTop="20dp"
+                        android:backgroundTint="@color/colorPrimary"
+                        android:text="Guardar"
+                        android:textColor="@android:color/white"
+                        app:cornerRadius="12dp" />
+
+                    <ProgressBar
+                        android:id="@+id/progressBarConfig"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:layout_marginTop="16dp"
+                        android:visibility="gone" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+        </com.google.android.material.card.MaterialCardView>
 
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/top_bar.xml
+++ b/app/src/main/res/layout/top_bar.xml
@@ -42,6 +42,20 @@
             android:visibility="gone" />
     </LinearLayout>
 
+    <!-- Config Button -->
+    <ImageButton
+        android:id="@+id/configButton"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_gravity="end"
+        android:background="@color/colorPrimary"
+        android:visibility="gone"
+        android:textColor="@android:color/white"
+        android:src="@drawable/ic_config_foreground"
+        android:layout_marginStart="10dp"
+        android:layout_marginEnd="10dp"
+        app:tint="@color/white" />
+
     <!-- Logout Button -->
     <ImageButton
         android:id="@+id/logoutButton"


### PR DESCRIPTION
## Contexto
La URL de la API solo se podía configurar desde `ConfigActivity` (accesible con un botón en Login, protegida por contraseña) y no se verificaba que la URL ingresada realmente funcionara. Si el usuario ponía una URL incorrecta no se enteraba hasta que fallaba el login u otra operación.

## Cambios
- **Primer arranque sin configurar** → se muestra `ConfigActivity` de forma obligatoria, **sin contraseña**, sin poder cancelar ni salir con Back.
- **Ya configurada** → no se muestra al inicio; acceso a configuración **in-app** vía botón de engranaje en la `TopBar` (Expedición/Asociar/Pickeo), protegido con contraseña `Aria9278`.
- **Health check al Guardar**: se prueba la URL contra la API (`ApiClient.checkHealth`, Retrofit descartable en `Dispatchers.IO`). Cualquier respuesta HTTP ⇒ URL válida; fallo de conexión/timeout/URL malformada ⇒ Toast **"La URL de la API es incorrecta"** y no guarda.
- `ApiClient.isConfigured()` (default `http://0.0.0.0`/vacío = no configurado).
- `api`/`palletRepository` pasados a getters para releer la URL vigente tras cambiarla in-app.
- **Rediseño de la pantalla de configuración**: tarjeta centrada, logo/fondo de la app, inputs redondeados, botones full-width con color primario.
- Bump de versión `1.3.1-dev` → `1.3.2-dev`.

## Verificación
Ciclo completo desarrollador → tester → QA. QA aprobó los 6 criterios en emulador real contra la API (`192.168.1.84:8080`): primer arranque obligatorio, URL incorrecta rechazada sin ANR, URL correcta guarda y loguea, rearranque no muestra config, config in-app con contraseña usa la URL nueva, sin regresiones en login/asociar/expedición. Rediseño verificado en vivo con captura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)