### PR TITLE
ci: fijar version recomendada de F-Droid en releases estables de main

### DIFF
--- a/.github/workflows/fdroid-publish.yml
+++ b/.github/workflows/fdroid-publish.yml
@@ -8,6 +8,16 @@ on:
         type: string
         required: false
         default: android-apk
+      current_version_code:
+        description: Si se pasa (solo releases estables de main), fija CurrentVersionCode (versión recomendada) en el metadata
+        type: string
+        required: false
+        default: ''
+      current_version:
+        description: Si se pasa, fija CurrentVersion (nombre de versión) en el metadata
+        type: string
+        required: false
+        default: ''
 
 concurrency:
   group: fdroid-publish
@@ -72,6 +82,31 @@ jobs:
           grep -q '^apksigner:' config.yml || echo "apksigner: /usr/bin/apksigner" >> config.yml
 
           printf '%s' "${{ secrets.ORG_ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > my-release-key.keystore
+
+          # Fijar la versión recomendada SOLO cuando el caller la pasa (pipeline de main =
+          # release estable). dev no la pasa, así que el prerelease no toca este puntero.
+          # Debe hacerse ANTES de 'fdroid update' para que el índice regenerado la refleje.
+          CURRENT_VERSION_CODE="${{ inputs.current_version_code }}"
+          CURRENT_VERSION="${{ inputs.current_version }}"
+          META="metadata/com.escorial.pallet_cocinas.yml"
+          if [ -n "$CURRENT_VERSION_CODE" ] && [ -f "$META" ]; then
+            if grep -q '^CurrentVersionCode:' "$META"; then
+              sed -i "s/^CurrentVersionCode:.*/CurrentVersionCode: ${CURRENT_VERSION_CODE}/" "$META"
+            else
+              echo "CurrentVersionCode: ${CURRENT_VERSION_CODE}" >> "$META"
+            fi
+            if [ -n "$CURRENT_VERSION" ]; then
+              if grep -q '^CurrentVersion:' "$META"; then
+                sed -i "s/^CurrentVersion:.*/CurrentVersion: '${CURRENT_VERSION}'/" "$META"
+              else
+                echo "CurrentVersion: '${CURRENT_VERSION}'" >> "$META"
+              fi
+            fi
+            echo "✅ Versión recomendada fijada en metadata: CurrentVersionCode=${CURRENT_VERSION_CODE} CurrentVersion=${CURRENT_VERSION}"
+          else
+            echo "ℹ️ Sin cambio de versión recomendada (no se pasó current_version_code; ej. publicación desde dev)"
+          fi
+
           fdroid update -c
 
       - name: Commit y push de cambios

--- a/.github/workflows/main-action.yml
+++ b/.github/workflows/main-action.yml
@@ -16,6 +16,10 @@ jobs:
     if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'dev'
     runs-on: windows-latest
 
+    outputs:
+      version: ${{ steps.versioning.outputs.version }}
+      versionCode: ${{ steps.versioning.outputs.versionCode }}
+
     env:
       ANDROID_HOME: C:\Android\Sdk
 
@@ -143,6 +147,9 @@ jobs:
 
           echo "version=$stableVersion" >> $env:GITHUB_ENV
           echo "versionCode=$newVersionCode" >> $env:GITHUB_ENV
+          # Exponer como outputs del job para pasarlos al workflow de F-Droid
+          echo "version=$stableVersion" >> $env:GITHUB_OUTPUT
+          echo "versionCode=$newVersionCode" >> $env:GITHUB_OUTPUT
 
       - name: Build release APK
         shell: pwsh
@@ -238,4 +245,8 @@ jobs:
     needs: build
     if: success()
     uses: ./.github/workflows/fdroid-publish.yml
+    with:
+      # Solo el pipeline de main (release estable) fija la versión recomendada.
+      current_version_code: ${{ needs.build.outputs.versionCode }}
+      current_version: ${{ needs.build.outputs.version }}
     secrets: inherit


### PR DESCRIPTION
## Contexto
El campo `CurrentVersionCode` del metadata del repo F-Droid (`metadata/com.escorial.pallet_cocinas.yml`) estaba pinneado a mano en `4` y ni el pipeline de `dev` ni el de `main` lo actualizaban. Como el CI genera `versionCode` muy altos (~20365), la "versión recomendada" del repo F-Droid quedaba congelada y desalineada de las versiones realmente publicadas.

## Cambio (opción 2)
Que **solo** el pipeline de `main` (release estable) fije la versión recomendada:
- `main-action.yml`: el job `build` expone `version`/`versionCode` como outputs y los pasa a `fdroid-publish`.
- `fdroid-publish.yml`: nuevos inputs opcionales `current_version_code` y `current_version`. Si se reciben (solo desde `main`), antes de `fdroid update` actualiza `CurrentVersionCode` y `CurrentVersion` en el metadata. `dev` no los pasa → los prereleases **no** tocan ese puntero.

Resultado: la versión recomendada del F-Droid pasa a seguir a la última **estable** de `main`, sin verse afectada por los prereleases de `dev`.

## Notas
- El cambio recién surte efecto en el próximo release `dev → main` (cuando estos workflows ya estén en `main`).
- No modifica la lógica de build ni de versionado existente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)